### PR TITLE
Compile the library using sanitizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ The scons script takes the following options:
 
 *  `run_check`: By default, when the `check` target is built, the tests are automatically run upon successful compilation. The option `run_check=0` disables this behavior.
 
+*  `sanitize_address`: Compiles the library with [AddressSanitizer (ASan)](https://github.com/google/sanitizers/wiki/AddressSanitizer) when set to 1. Great to check for stack/heap buffer overflows, memory leaks, ... Disabled by default.
+
+*  `sanitize_undefined`: When set to 1, compiles the library with [UndefinedBehaviorSanitizer (UBSan)](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html). UBSan detects undefined behavior at runtime in your code. Disabled by default. 
+
 ## Code coverage
 
 Code coverage is available using the `coverage=1` option in the building script. A report can be then generated the `coverage.sh` script (which uses lcov). 

--- a/SConstruct
+++ b/SConstruct
@@ -125,6 +125,12 @@ if int(debug):
 else:
 	env.Append(CCFLAGS = ['-O2'])
 
+sanitize_address = ARGUMENTS.get('sanitize_address', 0) # debug mode
+
+if int(sanitize_address):
+    env.Append(CCFLAGS = ['-fsanitize=address','-fno-omit-frame-pointer'])
+    env.Append(LINKFLAGS = ['-fsanitize=address','-fno-omit-frame-pointer'])
+
 coverage = ARGUMENTS.get('coverage', 0) # activate coverage
 if int(coverage):
     env.Append(CCFLAGS = ['-fprofile-arcs','-ftest-coverage', '-fno-inline', '-fno-inline-small-functions', '-fno-default-inline','-Wno-ignored-optimization-argument'])

--- a/SConstruct
+++ b/SConstruct
@@ -131,6 +131,15 @@ if int(sanitize_address):
     env.Append(CCFLAGS = ['-fsanitize=address','-fsanitize-address-use-after-scope','-fno-omit-frame-pointer'])
     env.Append(LINKFLAGS = ['-fsanitize=address','-fsanitize-address-use-after-scope','-fno-omit-frame-pointer'])
 
+
+sanitize_undefined = ARGUMENTS.get('sanitize_undefined', 0) # debug mode
+
+if int(sanitize_undefined):
+    env.Append(CCFLAGS = ['-fsanitize=undefined','-fno-omit-frame-pointer'])
+    env.Append(LINKFLAGS = ['-fsanitize=undefined','-fno-omit-frame-pointer'])
+
+
+
 coverage = ARGUMENTS.get('coverage', 0) # activate coverage
 if int(coverage):
     env.Append(CCFLAGS = ['-fprofile-arcs','-ftest-coverage', '-fno-inline', '-fno-inline-small-functions', '-fno-default-inline','-Wno-ignored-optimization-argument'])

--- a/SConstruct
+++ b/SConstruct
@@ -128,8 +128,8 @@ else:
 sanitize_address = ARGUMENTS.get('sanitize_address', 0) # debug mode
 
 if int(sanitize_address):
-    env.Append(CCFLAGS = ['-fsanitize=address','-fno-omit-frame-pointer'])
-    env.Append(LINKFLAGS = ['-fsanitize=address','-fno-omit-frame-pointer'])
+    env.Append(CCFLAGS = ['-fsanitize=address','-fsanitize-address-use-after-scope','-fno-omit-frame-pointer'])
+    env.Append(LINKFLAGS = ['-fsanitize=address','-fsanitize-address-use-after-scope','-fno-omit-frame-pointer'])
 
 coverage = ARGUMENTS.get('coverage', 0) # activate coverage
 if int(coverage):

--- a/src/aez/aez.c
+++ b/src/aez/aez.c
@@ -185,21 +185,15 @@ static void store(void *p, uint8x16_t x) { *(uint8x16_t *)p = x; }
 
 #define vxor3(x,y,z)        vxor(vxor(x,y),z)
 #define vxor4(w,x,y,z)      vxor(vxor(w,x),vxor(y,z))
-#define load_partial(p,n)   loadu(p)
 
-/*
-Might need a version like this if, for example, we want to load a 12-byte nonce
-into a 16-byte block.
-
+// This version of load_partial raised errors (stack-buffer-overflow)
+// with clang's address sanitizers for obvious reasons
+//#define load_partial(p,n)   loadu(p)
 static block load_partial(const void *p, unsigned n) {
-    if ((intptr_t)p % 16 == 0) return load(p);
-    else {
-        block tmp; unsigned i;
-        for (i=0; i<n; i++) ((char*)&tmp)[i] = ((char*)p)[i];
-        return tmp;
-    }
+    block tmp = {0UL, 0UL}; unsigned i;
+    for (i=0; i<n; i++) ((char*)&tmp)[i] = ((const char*)p)[i];
+    return tmp;
 }
-*/
 
 static const unsigned char pad[] = {0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
                                     0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,

--- a/tests/test_fpe.cpp
+++ b/tests/test_fpe.cpp
@@ -36,7 +36,7 @@ using namespace std;
 TEST(fpe, correctness) {
     
     for (size_t i = 1; i <= 20*16; i++) {
-        
+//        std::cout << i << std::endl;
         string in_enc = sse::crypto::random_string(i);
         string out_enc, out_dec;
         


### PR DESCRIPTION
ASan and UBSan are great to find nasty bugs. I added new compile time options (to pass to scons) to be able to compile the library with these tools. 

I was able to find a bug in AEZ' reference implementation. 

Some documentation (in the README) was added. 