### PR TITLE
Enable static and dynamic analysis in Travis

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,-clang-diagnostic-#warnings,-clang-diagnostic-#pragma-messages,modernize-*,-modernize-use-auto,bugprone-*, readability-*,-readability-avoid-const-params-in-decls,misc-*,-misc-unused-parameters,performance-*,cert-*,-cert-err60-cpp,google-*,-google-runtime-references,llvm-*,-llvm-header-guard'
+Checks:          'clang-diagnostic-*,-clang-diagnostic-#warnings,-clang-diagnostic-#pragma-messages,modernize-*,-modernize-use-auto,bugprone-*, readability-*,-readability-avoid-const-params-in-decls,misc-*,-misc-unused-parameters,performance-*,cert-*,google-*,-google-runtime-references,llvm-*,-llvm-header-guard'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
 FormatStyle:     none
 User:            rbost
+WarningsAsErrors:   '*'
 CheckOptions:    
   - key:             google-readability-braces-around-statements.ShortStatementLines
     value:           '1'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,-clang-diagnostic-#warnings,-clang-diagnostic-#pragma-messages,modernize-*,-modernize-use-auto,bugprone-*, readability-*,-readability-avoid-const-params-in-decls,misc-*,-misc-unused-parameters,performance-*,cert-*,google-*,-google-runtime-references,llvm-*,-llvm-header-guard'
+Checks:          'clang-diagnostic-*,-clang-diagnostic-#warnings,-clang-diagnostic-#pragma-messages,modernize-*,-modernize-use-auto,bugprone-*, readability-*,-readability-avoid-const-params-in-decls,misc-*,-misc-unused-parameters,performance-*,cert-*,-cert-err60-cpp,google-*,-google-runtime-references,llvm-*,-llvm-header-guard'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,13 +24,15 @@ addons:
 
 
 env:
-- MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" STATIC_ANALYSIS=true
+  - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" STATIC_ANALYSIS=false
+  - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" STATIC_ANALYSIS=true
 
 before_install:
   - eval "${MATRIX_EVAL}"  
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
   
 install:  
+  - if [ ! "${STATIC_ANALYSIS}" == "true" ]; then sudo apt-get install g++-4.9; fi # upload the report to coveralls
   - cd install_dependencies
   - ./install_libsodium.sh
   - ./install_relic_ubuntu_14_easy.sh
@@ -49,5 +51,6 @@ script:
   
 
 after_success:
-  # - ./coverage/gen_coverage.sh # get the code coverage
-  # - ./coverage/upload_report.sh # upload the report to coveralls
+  - ./coverage/gen_coverage.sh # get the code coverage
+  - if [ ! "${STATIC_ANALYSIS}" == "true" ]; then ./coverage/upload_report.sh; fi # upload the report to coveralls
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ addons:
        - libgmp-dev
        - lcov
        - cppcheck
-       - clang-tidy
 
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
 
 
 env:
-- MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+- MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" STATIC_ANALYSIS=true
 
 before_install:
   - eval "${MATRIX_EVAL}"
@@ -34,9 +34,14 @@ before_install:
   # - sudo ldconfig
  
 script:
-  # - scons check debug=1 coverage=1 static_relic=1 sanitize_address=1 sanitize_undefined=1
-  - ./scripts/cppcheck.sh
+  - if [ ! "${STATIC_ANALYSIS}" == "true" ]; then
+      scons check debug=1 coverage=1 static_relic=1 sanitize_address=1 sanitize_undefined=1;
+    fi
+  - if [ "${STATIC_ANALYSIS}" == "true" ]; then
+      ./scripts/cppcheck.sh;
+    fi
+  
 
 after_success:
-  # - ./coverage/gen_coverage.sh # get the code coverage
+  - ./coverage/gen_coverage.sh # get the code coverage
   # - ./coverage/upload_report.sh # upload the report to coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,15 @@ addons:
 
 env: MATRIX_EVAL="" 
 
+install:  
+  - cd install_dependencies
+  - ./install_libsodium.sh
+  - ./install_relic_ubuntu_14_easy.sh
+  - cd ..
+  - gem install coveralls-lcov
+  - sudo ldconfig
+
+
 matrix:
    include:
       - env: 
@@ -36,6 +45,10 @@ matrix:
                  - g++-4.9 
         before_install:
            - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
+        after_success:
+           - ./coverage/gen_coverage.sh # get the code coverage
+           - ./coverage/upload_report.sh # upload the report to coveralls
+
                  
       - env: 
           - STATIC_ANALYSIS=true
@@ -48,27 +61,15 @@ matrix:
                  - cppcheck
                  - libclang-common-5.0-dev # to get the headers right
                  - clang-tidy-5.0
-
+        script:
+           - ./scripts/cppcheck.sh 
+           - ./scripts/cppcheck.sh 
   
-install:  
-  - cd install_dependencies
-  - ./install_libsodium.sh
-  - ./install_relic_ubuntu_14_easy.sh
-  - cd ..
-  - gem install coveralls-lcov
-  - sudo ldconfig
  
 script:
-  - if [ ! "${STATIC_ANALYSIS}" == "true" ]; then
+  - if [ "${STATIC_ANALYSIS}" == "false" ]; then
       scons check debug=1 coverage=1 static_relic=1 sanitize_address=1 sanitize_undefined=1;
-    fi
-  - if [ "${STATIC_ANALYSIS}" == "true" ]; then
-      ./scripts/cppcheck.sh;
-      ./scripts/tidy.sh;
     fi
   
 
-after_success:
-  - ./coverage/gen_coverage.sh # get the code coverage
-  - if [ ! "${STATIC_ANALYSIS}" == "true" ]; then ./coverage/upload_report.sh; fi # upload the report to coveralls
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,35 +12,31 @@ addons:
    apt:
      sources:
        - ubuntu-toolchain-r-test
+       - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main'
+         key_url: 'http://llvm.org/apt/llvm-snapshot.gpg.key'
      packages:
-       # - g++-4.9
+       - g++-4.9
        - libssl-dev
        - libgmp-dev
        - lcov
        - cppcheck
+       - clang-tidy-5.0
 
 
 env:
 - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" STATIC_ANALYSIS=true
 
 before_install:
-  - eval "${MATRIX_EVAL}"
-  - sudo wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-  - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
-  - sudo apt-get update -qq
-  
-  # - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
+  - eval "${MATRIX_EVAL}"  
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
   
 install:  
-  - if [ ! "${STATIC_ANALYSIS}" == "true" ]; then
-      sudo apt-get install clang-tidy-5.0 -y;
-    fi
-  # - cd install_dependencies
-  # - ./install_libsodium.sh
-  # - ./install_relic_ubuntu_14_easy.sh
-  # - cd ..
-  # - gem install coveralls-lcov
-  # - sudo ldconfig
+  - cd install_dependencies
+  - ./install_libsodium.sh
+  - ./install_relic_ubuntu_14_easy.sh
+  - cd ..
+  - gem install coveralls-lcov
+  - sudo ldconfig
  
 script:
   - if [ ! "${STATIC_ANALYSIS}" == "true" ]; then
@@ -53,5 +49,5 @@ script:
   
 
 after_success:
-  - ./coverage/gen_coverage.sh # get the code coverage
+  # - ./coverage/gen_coverage.sh # get the code coverage
   # - ./coverage/upload_report.sh # upload the report to coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
        - libgmp-dev
        - lcov
        - cppcheck
+       - clang-tidy
 
 
 env:
@@ -39,6 +40,7 @@ script:
     fi
   - if [ "${STATIC_ANALYSIS}" == "true" ]; then
       ./scripts/cppcheck.sh;
+      ./scripts/tidy.sh;
     fi
   
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,22 @@ addons:
        - lcov
 
 
-env: MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" 
+env: MATRIX_EVAL="" 
 
 matrix:
    include:
-      - env: STATIC_ANALYSIS=false
+      - env: 
+          - STATIC_ANALYSIS=false
+          - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
         addons:
             apt:
               sources: *basic_sources
               packages:
                  - *basic_deps
                  - g++-4.9 
-      - env: STATIC_ANALYSIS=true
+      - env: 
+          - STATIC_ANALYSIS=true
+          - CLANG_TIDY=clang-tidy-5.0
         addons:
            apt:
               sources: *basic_sources

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
      sources:
        - ubuntu-toolchain-r-test
      packages:
-       - g++-4.9
+       # - g++-4.9
        - libssl-dev
        - libgmp-dev
        - lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,16 @@ env:
 
 before_install:
   - eval "${MATRIX_EVAL}"
+  - sudo wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+  - echo "deb deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get update -qq
+  
   # - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
+  
+install:  
+  - if [ ! "${STATIC_ANALYSIS}" == "true" ]; then
+      sudo apt-get install clang-tidy-5.0 -y;
+    fi
   # - cd install_dependencies
   # - ./install_libsodium.sh
   # - ./install_relic_ubuntu_14_easy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,17 +26,17 @@ env:
 before_install:
   - eval "${MATRIX_EVAL}"
   # - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
-  - cd install_dependencies
-  - ./install_libsodium.sh
-  - ./install_relic_ubuntu_14_easy.sh
-  - cd ..
-  - gem install coveralls-lcov
-  - sudo ldconfig
+  # - cd install_dependencies
+  # - ./install_libsodium.sh
+  # - ./install_relic_ubuntu_14_easy.sh
+  # - cd ..
+  # - gem install coveralls-lcov
+  # - sudo ldconfig
  
 script:
-  - scons check debug=1 coverage=1 static_relic=1 sanitize_address=1 sanitize_undefined=1
+  # - scons check debug=1 coverage=1 static_relic=1 sanitize_address=1 sanitize_undefined=1
   - ./scripts/cppcheck.sh
 
 after_success:
-  - ./coverage/gen_coverage.sh # get the code coverage
-  - ./coverage/upload_report.sh # upload the report to coveralls
+  # - ./coverage/gen_coverage.sh # get the code coverage
+  # - ./coverage/upload_report.sh # upload the report to coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ matrix:
               packages:
                  - *basic_deps
                  - cppcheck
+                 - libclang-common-5.0-dev # to get the headers right
                  - clang-tidy-5.0
 
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - sudo ldconfig
  
 script:
-  - scons check debug=1 coverage=1 static_relic=1
+  - scons check debug=1 coverage=1 static_relic=1 sanitize_address=1 sanitize_undefined=1
 
 after_success:
   - ./coverage/gen_coverage.sh # get the code coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ addons:
        - libssl-dev
        - libgmp-dev
        - lcov
+       - cppcheck
 
 
 env:
@@ -34,6 +35,7 @@ before_install:
  
 script:
   - scons check debug=1 coverage=1 static_relic=1 sanitize_address=1 sanitize_undefined=1
+  - ./scripts/cppcheck.sh
 
 after_success:
   - ./coverage/gen_coverage.sh # get the code coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,15 @@ matrix:
    include:
       - env: 
           - STATIC_ANALYSIS=false
-          - MATRIX_EVAL="export CC="gcc-4.9" CXX="g++-4.9""
         addons:
             apt:
               sources: *basic_sources
               packages:
                  - *basic_deps
                  - g++-4.9 
+        before_install:
+           - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
+                 
       - env: 
           - STATIC_ANALYSIS=true
           - CLANG_TIDY=clang-tidy-5.0
@@ -46,11 +48,8 @@ matrix:
                  - cppcheck
                  - clang-tidy-5.0
 
-before_install:
-  - eval "${MATRIX_EVAL}"  
   
 install:  
-  - if [ ! "${STATIC_ANALYSIS}" == "true" ]; then sudo apt-get install g++-4.9; fi # upload the report to coveralls
   - cd install_dependencies
   - ./install_libsodium.sh
   - ./install_relic_ubuntu_14_easy.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,26 @@ addons:
        - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main'
          key_url: 'http://llvm.org/apt/llvm-snapshot.gpg.key'
      packages:
-       - g++-4.9
        - libssl-dev
        - libgmp-dev
        - lcov
-       - cppcheck
-       - clang-tidy-5.0
 
 
-env:
-  - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" STATIC_ANALYSIS=false
-  - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" STATIC_ANALYSIS=true
+env: MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9" 
+
+matrix:
+   include:
+      - env: STATIC_ANALYSIS=false
+        addons:
+            apt:
+              packages:
+                 - g++-4.9 
+      - env: STATIC_ANALYSIS=true
+        addons:
+           apt:
+              packages:
+                 - cppcheck
+                 - clang-tidy-5.0
 
 before_install:
   - eval "${MATRIX_EVAL}"  

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
 before_install:
   - eval "${MATRIX_EVAL}"
   - sudo wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-  - echo "deb deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
+  - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
   - sudo apt-get update -qq
   
   # - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
    include:
       - env: 
           - STATIC_ANALYSIS=false
-          - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+          - MATRIX_EVAL="export CC="gcc-4.9" CXX="g++-4.9""
         addons:
             apt:
               sources: *basic_sources
@@ -48,7 +48,6 @@ matrix:
 
 before_install:
   - eval "${MATRIX_EVAL}"  
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
   
 install:  
   - if [ ! "${STATIC_ANALYSIS}" == "true" ]; then sudo apt-get install g++-4.9; fi # upload the report to coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,15 @@ language: cpp
 os: linux
 dist: trusty
 sudo: required
+
+
 addons:
    apt:
-     sources:
+     sources: &basic_sources
        - ubuntu-toolchain-r-test
        - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main'
          key_url: 'http://llvm.org/apt/llvm-snapshot.gpg.key'
-     packages:
+     packages: &basic_deps
        - libssl-dev
        - libgmp-dev
        - lcov
@@ -27,12 +29,16 @@ matrix:
       - env: STATIC_ANALYSIS=false
         addons:
             apt:
+              sources: *basic_sources
               packages:
+                 - *basic_deps
                  - g++-4.9 
       - env: STATIC_ANALYSIS=true
         addons:
            apt:
+              sources: *basic_sources
               packages:
+                 - *basic_deps
                  - cppcheck
                  - clang-tidy-5.0
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1412/badge)](https://bestpractices.coreinfrastructure.org/projects/1412)
 
 
-[![build status](https://badges.herokuapp.com/travis/OpenSSE/crypto-tk?branch=ci_analysis&label=Status&env=STATIC_ANALYSIS=false)](https://travis-ci.org/OpenSSE/crypto-tk)
-[![static analysis](https://badges.herokuapp.com/travis/OpenSSE/crypto-tk?branch=ci_analysis&label=Static%20Analysis&env=STATIC_ANALYSIS=true)](https://travis-ci.org/OpenSSE/crypto-tk)
+[![build status](https://badges.herokuapp.com/travis/OpenSSE/crypto-tk?branch=ci_analysis&label=build&env=STATIC_ANALYSIS=false)](https://travis-ci.org/OpenSSE/crypto-tk)
+[![static analysis](https://badges.herokuapp.com/travis/OpenSSE/crypto-tk?branch=ci_analysis&label=static%20analysis&env=STATIC_ANALYSIS=true)](https://travis-ci.org/OpenSSE/crypto-tk)
 
 
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 [![Coverage Status](https://coveralls.io/repos/github/OpenSSE/crypto-tk/badge.svg)](https://coveralls.io/github/OpenSSE/crypto-tk)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1412/badge)](https://bestpractices.coreinfrastructure.org/projects/1412)
 
+
+[![build status](https://badges.herokuapp.com/travis/OpenSSE/crypto-tk?branch=ci_analysis&label=Status&env=STATIC_ANALYSIS=false)](https://travis-ci.org/OpenSSE/crypto-tk)
+[![static analysis](https://badges.herokuapp.com/travis/OpenSSE/crypto-tk?branch=ci_analysis&label=Static%20Analysis&env=STATIC_ANALYSIS=true)](https://travis-ci.org/OpenSSE/crypto-tk)
+
+
+
+
 The SSE protocols rely on high level cryptographic features such as pseudo-random functions, hash functions, encryption schemes, or incremental set hashing. The cryptographic layer provides interfaces and implementations of these features. 
 
 For now, the hash function and encryption implementations rely on OpenSSL. This might (and probably will) in the future. However, this will have no influence on the code written using this library: the interfaces to the cryptographic services are *opaque*. It means that all implementation details are hidden. In particular, even if the implementation changes, the header files shouldn't.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # OpenSSE's Cryptographic Toolkit
 
-[![build status](https://travis-ci.org/OpenSSE/crypto-tk.svg?branch=master)](https://travis-ci.org/OpenSSE/crypto-tk) 
+[![build status](https://badges.herokuapp.com/travis/OpenSSE/crypto-tk?branch=master&label=build&env=STATIC_ANALYSIS=false)](https://travis-ci.org/OpenSSE/crypto-tk)
+[![static analysis](https://badges.herokuapp.com/travis/OpenSSE/crypto-tk?branch=master&label=static%20analysis&env=STATIC_ANALYSIS=true)](https://travis-ci.org/OpenSSE/crypto-tk)
 [![Coverage Status](https://coveralls.io/repos/github/OpenSSE/crypto-tk/badge.svg)](https://coveralls.io/github/OpenSSE/crypto-tk)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1412/badge)](https://bestpractices.coreinfrastructure.org/projects/1412)
 
 
-[![build status](https://badges.herokuapp.com/travis/OpenSSE/crypto-tk?branch=ci_analysis&label=build&env=STATIC_ANALYSIS=false)](https://travis-ci.org/OpenSSE/crypto-tk)
-[![static analysis](https://badges.herokuapp.com/travis/OpenSSE/crypto-tk?branch=ci_analysis&label=static%20analysis&env=STATIC_ANALYSIS=true)](https://travis-ci.org/OpenSSE/crypto-tk)
 
 
 

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -3,4 +3,4 @@ if [[ -z $CPPCHECK ]]; then
 	CPPCHECK="cppcheck"
 fi
 
-eval "$CPPCHECK src --quiet --verbose --std=c++11 --force  --enable=warning,performance,portability,style --error-exitcode=1 --report-progress  --inline-suppr"
+eval "$CPPCHECK src -i src/mbedtls --quiet --verbose --std=c++11 --force  --enable=warning,performance,portability,style --error-exitcode=1 --report-progress  --inline-suppr"

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 if [[ -z $CPPCHECK ]]; then
 	CPPCHECK="cppcheck"
 fi

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -3,4 +3,4 @@ if [[ -z $CPPCHECK ]]; then
 	CPPCHECK="cppcheck"
 fi
 
-eval "$CPPCHECK src -i src/mbedtls --quiet --verbose --std=c++11 --force  --enable=warning,performance,portability,style --error-exitcode=1 --report-progress  --inline-suppr"
+eval "$CPPCHECK src -i src/mbedtls --quiet --verbose --std=c++11 --force  --enable=warning,performance,portability,style --error-exitcode=1 --report-progress  --inline-suppr --xml"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 
 if [[ -z $CLANG_FORMAT ]]; then
 	CLANG_FORMAT="clang-format"

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /bin/bash
 if [[ -z $CLANG_TIDY ]]; then
 	CLANG_TIDY="clang-tidy"
 fi

--- a/src/hmac.hpp
+++ b/src/hmac.hpp
@@ -190,9 +190,6 @@ void HMac<H, N>::hmac(const unsigned char* in,
 
     key_.unlock();
 
-    // set the buffer to 0x00
-    memset(buffer, 0, kHMACKeySize);
-
     // copy the key to the buffer
     memcpy(buffer, key_.data(), kKeySize);
 

--- a/src/ppke/GMPpke.hpp
+++ b/src/ppke/GMPpke.hpp
@@ -27,6 +27,7 @@ constexpr unsigned int  kPPKEStatisticalSecurity = 32;
 constexpr static size_t kPPKEPrfOutputSize
     = relicxx::PairingGroup::kPrfOutputSize;
 
+// cppcheck-suppress constStatement
 using PPKE_HKDF = sse::crypto::HMac<sse::crypto::Hash, 12 * FP_BYTES>;
 
 using tag_type = std::array<uint8_t, kTagSize>;

--- a/src/prg.hpp
+++ b/src/prg.hpp
@@ -214,7 +214,7 @@ public:
     ///
     static inline std::string derive(Key<kKeySize>&& k, const size_t len)
     {
-        return Prg::derive(std::move(k), 0, len);
+        return derive(std::move(k), 0, len);
     };
 
     ///

--- a/src/puncturable_enc.hpp
+++ b/src/puncturable_enc.hpp
@@ -69,6 +69,7 @@ using master_key_type = Key<kMasterKeySize>;
 /// @relatesalso PuncturableEncryption
 const static size_t kCiphertextSize = 90;
 /// @brief Type of a ciphertext created using puncturable encryption
+// cppcheck-suppress constStatement
 using ciphertext_type = std::array<uint8_t, kCiphertextSize>;
 
 


### PR DESCRIPTION
Enable static analysis tools (clang-tidy and cppcheck) in Travis. 
Enable ASan and UBSan when compiling the tests.

Update the README file so that two badges are shown: one for the checks and the other for the static analysis.