### PR TITLE
Improve the performance of consecutive range-constrained PRF evaluations

### DIFF
--- a/bench/bench_rcprf.cpp
+++ b/bench/bench_rcprf.cpp
@@ -28,29 +28,26 @@ using sse::crypto::Key;
 using sse::crypto::RCPrf;
 using sse::crypto::RCPrfParams;
 
-static void BM_RCPrf_eval_range_loop(benchmark::State& state)
+static void BM_RCPrf_eval(benchmark::State& state)
 {
     uint8_t  depth          = state.range(0);
     uint64_t max_leaf_index = RCPrfParams::max_leaf_index_generic(depth);
 
     std::random_device                      rnd;
     std::mt19937_64                         rnd_gen(rnd());
-    std::uniform_int_distribution<uint64_t> unif_dist(
-        0, max_leaf_index - state.range(1));
+    std::uniform_int_distribution<uint64_t> unif_dist(0, max_leaf_index);
 
     RCPrf<32> rcprf(Key<RCPrfParams::kKeySize>(), depth);
 
     for (auto _ : state) {
         // randomly generate a starting point
-        uint64_t start_index = unif_dist(rnd_gen);
-        for (uint64_t i = 0; i < static_cast<uint64_t>(state.range(1)); i++) {
-            rcprf.eval(start_index + i);
-        }
+        uint64_t index = unif_dist(rnd_gen);
+        rcprf.eval(index);
     }
-    state.SetItemsProcessed(state.iterations() * state.range(1));
+    state.SetItemsProcessed(state.iterations());
 }
 
-static void BM_RCPrf_eval_range_native(benchmark::State& state)
+static void BM_RCPrf_eval_range(benchmark::State& state)
 {
     uint8_t  depth          = state.range(0);
     uint64_t max_leaf_index = RCPrfParams::max_leaf_index_generic(depth);
@@ -103,12 +100,9 @@ static void BM_RCPrf_eval_range_constrain(benchmark::State& state)
     state.SetItemsProcessed(state.iterations() * state.range(1));
 }
 
-BENCHMARK(BM_RCPrf_eval_range_loop)
-    ->RangeMultiplier(2)
-    ->Ranges({{48, 48}, {8, 128}});
-// ->Ranges({{16, 32}, {8, 128}});
+BENCHMARK(BM_RCPrf_eval)->RangeMultiplier(2)->Range(48, 48);
 
-BENCHMARK(BM_RCPrf_eval_range_native)
+BENCHMARK(BM_RCPrf_eval_range)
     ->RangeMultiplier(2)
     ->Ranges({{48, 48}, {8, 128}});
 // ->Ranges({{16, 32}, {8, 128}});

--- a/bench/bench_rcprf.cpp
+++ b/bench/bench_rcprf.cpp
@@ -22,6 +22,8 @@
 
 #include <benchmark/benchmark.h>
 
+#include <random>
+
 using sse::crypto::Key;
 using sse::crypto::RCPrf;
 using sse::crypto::RCPrfParams;
@@ -31,17 +33,50 @@ static void BM_RCPrf_eval_all_loop(benchmark::State& state)
     uint8_t  depth          = state.range(0);
     uint64_t max_leaf_index = RCPrfParams::max_leaf_index_generic(depth);
 
+    std::random_device                      rnd;
+    std::mt19937_64                         rnd_gen(rnd());
+    std::uniform_int_distribution<uint64_t> unif_dist(
+        0, max_leaf_index - state.range(1));
+
     RCPrf<32> rcprf(Key<RCPrfParams::kKeySize>(), depth);
 
-    size_t i = 0;
     for (auto _ : state) {
-        rcprf.eval(i);
-
-        i = (i + 1) % (max_leaf_index + 1);
+        // randomly generate a starting point
+        uint64_t start_index = unif_dist(rnd_gen);
+        for (uint64_t i = 0; i < static_cast<uint64_t>(state.range(1)); i++) {
+            rcprf.eval(start_index + i);
+        }
     }
-    state.SetItemsProcessed(state.iterations());
+    state.SetItemsProcessed(state.iterations() * state.range(1));
+}
+
+static void BM_RCPrf_eval_all_range(benchmark::State& state)
+{
+    uint8_t  depth          = state.range(0);
+    uint64_t max_leaf_index = RCPrfParams::max_leaf_index_generic(depth);
+
+    std::random_device                      rnd;
+    std::mt19937_64                         rnd_gen(rnd());
+    std::uniform_int_distribution<uint64_t> unif_dist(
+        0, max_leaf_index - state.range(1));
+
+    RCPrf<32> rcprf(Key<RCPrfParams::kKeySize>(), depth);
+
+    auto callback = [](size_t, std::array<uint8_t, 32>) {};
+
+    for (auto _ : state) {
+        // randomly generate a starting point
+        uint64_t start_index = unif_dist(rnd_gen);
+
+        rcprf.eval_range(start_index, start_index + state.range(1), callback);
+    }
+    state.SetItemsProcessed(state.iterations() * state.range(1));
 }
 
 BENCHMARK(BM_RCPrf_eval_all_loop)
     ->RangeMultiplier(2)
-    ->Range(4, 62); // Arg(4)->Arg(8)->Arg(16)->Arg(4)->Arg(4);
+    ->Ranges({{16, 32}, {8, 128}});
+
+BENCHMARK(BM_RCPrf_eval_all_range)
+    ->RangeMultiplier(2)
+    ->Ranges({{16, 32}, {8, 128}});

--- a/src/include/sse/crypto/rcprf.hpp
+++ b/src/include/sse/crypto/rcprf.hpp
@@ -1371,10 +1371,6 @@ void ConstrainedRCPrf<NBYTES>::eval_range(uint64_t             min,
             // we are passed the interesting elements
             return;
         }
-        if (min > elt_max_leaf) {
-            // we are not there yet
-            continue;
-        }
         if (RCPrfParams::ranges_intersect(
                 min, max, elt_min_leaf, elt_max_leaf)) {
             elt->eval_range(std::max(min, elt_min_leaf),

--- a/src/include/sse/crypto/rcprf.hpp
+++ b/src/include/sse/crypto/rcprf.hpp
@@ -1363,10 +1363,22 @@ void ConstrainedRCPrf<NBYTES>::eval_range(uint64_t             min,
             + std::to_string(max_leaf()) + ")");
     }
     for (const auto& elt : elements_) {
+        uint64_t elt_min_leaf = elt->min_leaf();
+        uint64_t elt_max_leaf = elt->max_leaf();
+
+        // remember that elements_ is ordered by increasing min_leaf
+        if (max < elt_min_leaf) {
+            // we are passed the interesting elements
+            return;
+        }
+        if (min > elt_max_leaf) {
+            // we are not there yet
+            continue;
+        }
         if (RCPrfParams::ranges_intersect(
-                min, max, elt->min_leaf(), elt->max_leaf())) {
-            elt->eval_range(std::max(min, elt->min_leaf()),
-                            std::min(max, elt->max_leaf()),
+                min, max, elt_min_leaf, elt_max_leaf)) {
+            elt->eval_range(std::max(min, elt_min_leaf),
+                            std::min(max, elt_max_leaf),
                             callback);
         }
     }

--- a/tests/test_rcprf.cpp
+++ b/tests/test_rcprf.cpp
@@ -157,11 +157,10 @@ TEST(rc_prf, range_eval)
         reference[i] = rc_prf.eval(i);
     }
 
-    auto check_callback
-        = [&reference, &rc_prf](uint64_t                leaf_index,
-                                std::array<uint8_t, 16> leaf_value) {
-              EXPECT_EQ(leaf_value, reference[leaf_index]);
-          };
+    auto check_callback = [&reference](uint64_t                leaf_index,
+                                       std::array<uint8_t, 16> leaf_value) {
+        EXPECT_EQ(leaf_value, reference[leaf_index]);
+    };
     for (uint64_t min = 0;
          min <= sse::crypto::RCPrfParams::max_leaf_index(test_depth);
          min++) {
@@ -192,11 +191,10 @@ TEST(rc_prf, constrain_range_eval)
         reference[i] = rc_prf.eval(i);
     }
 
-    auto check_callback
-        = [&reference, &rc_prf](uint64_t                leaf_index,
-                                std::array<uint8_t, 16> leaf_value) {
-              EXPECT_EQ(leaf_value, reference[leaf_index]);
-          };
+    auto check_callback = [&reference](uint64_t                leaf_index,
+                                       std::array<uint8_t, 16> leaf_value) {
+        EXPECT_EQ(leaf_value, reference[leaf_index]);
+    };
 
     for (uint64_t constrain_min = 0;
          constrain_min <= sse::crypto::RCPrfParams::max_leaf_index(test_depth);

--- a/tests/test_rcprf.cpp
+++ b/tests/test_rcprf.cpp
@@ -259,11 +259,25 @@ TEST(rc_prf, eval_constrain_exceptions)
     EXPECT_THROW(constrained_rc_prf.eval(range_min - 1), std::out_of_range);
     EXPECT_THROW(constrained_rc_prf.eval(range_max + 1), std::out_of_range);
 
+    // Exceptions raised by ConstrainedRCPrf::eval_range
+    EXPECT_THROW(constrained_rc_prf.eval_range(
+                     0, 1UL << (test_depth + 1), empty_callback),
+                 std::out_of_range);
+    EXPECT_THROW(
+        constrained_rc_prf.eval_range(0, 1UL << test_depth, empty_callback),
+        std::out_of_range);
+    EXPECT_THROW(constrained_rc_prf.eval_range(2, 1, empty_callback),
+                 std::invalid_argument);
+
     // Exceptions raised by ConstrainedRCPrfLeafElement::eval
     std::array<uint8_t, 16> buffer = sse::crypto::random_bytes<uint8_t, 16>();
     sse::crypto::ConstrainedRCPrfLeafElement<16> leaf(buffer, test_depth, 1);
     EXPECT_THROW(leaf.eval(0), std::out_of_range);
     EXPECT_THROW(leaf.eval(2), std::out_of_range);
+
+    // Exceptions raised by ConstrainedRCPrfLeafElement::eval_range
+    EXPECT_THROW(leaf.eval_range(0, 0, empty_callback), std::out_of_range);
+    EXPECT_THROW(leaf.eval_range(2, 0, empty_callback), std::invalid_argument);
 
     // Exceptions raised by ConstrainedRCPrfInnerElement::eval
     range_min              = 4;
@@ -278,6 +292,13 @@ TEST(rc_prf, eval_constrain_exceptions)
         range_max);
     EXPECT_THROW(elt.eval(range_min - 1), std::out_of_range);
     EXPECT_THROW(elt.eval(range_max + 1), std::out_of_range);
+
+    // Exceptions raised by ConstrainedRCPrfInnerElement::eval_range
+    EXPECT_THROW(elt.eval_range(range_min - 1, range_max, empty_callback),
+                 std::out_of_range);
+    EXPECT_THROW(elt.eval_range(range_min, range_max + 1, empty_callback),
+                 std::out_of_range);
+    EXPECT_THROW(elt.eval_range(2, 0, empty_callback), std::invalid_argument);
 }
 
 // Exceptions that can be raised when re-constaining an already constrained


### PR DESCRIPTION
To evaluate a RCPrf (or ConstrainedRCPrf) object on consecutive inputs, we can only use a loop, and call RCPrf::eval in the body of this loop. This is quite inefficient as similar computations can be performed several times. Indeed, for a RCPrf based on a tree of depth `d`, it requires `N*d` PRG evaluations.

This PR implements the efficient evaluation of a RCPrf on a range, using a standard recursion technique which ensures that no Prg evaluation is done twice. As usual, this can be seen as a time-memory tradeoff (the used memory in that case is the stack). It can result in a `log N` speedup in the best case (however, this needs to be checked).

In practice, the improvement is big, as can be seen by running the `benchmark_rcprf` benchmark. My run follows:
```
----------------------------------------------------------------------------
Benchmark                                     Time           CPU Iterations
----------------------------------------------------------------------------
BM_RCPrf_eval/48                         693495 ns     692542 ns       1004   1.41011k items/s
BM_RCPrf_eval_range/48/8                 831000 ns     830829 ns        835   9.40326k items/s
BM_RCPrf_eval_range/48/16                994640 ns     993869 ns        733   15.7214k items/s
BM_RCPrf_eval_range/48/32               1216956 ns    1216353 ns        575   25.6916k items/s
BM_RCPrf_eval_range/48/64               1662742 ns    1662546 ns        421   37.5929k items/s
BM_RCPrf_eval_range/48/128              2688190 ns    2687935 ns        261   46.5041k items/s
```

As expected, the speedup increases with the range's size (the second number in the benchmarks' names). Similar results can be obtained after the PRF has been constrained (the figures do not account for the constrain time):
```
----------------------------------------------------------------------------
Benchmark                                     Time           CPU Iterations
----------------------------------------------------------------------------
BM_RCPrf_eval_range_constrain/48/8        78154 ns      78063 ns       8691   100.079k items/s
BM_RCPrf_eval_range_constrain/48/16      181070 ns     180989 ns       3857   86.3313k items/s
BM_RCPrf_eval_range_constrain/48/32      404702 ns     404196 ns       1753    77.314k items/s
BM_RCPrf_eval_range_constrain/48/64      888989 ns     888785 ns        809   70.3207k items/s
BM_RCPrf_eval_range_constrain/48/128    1820928 ns    1820510 ns        384   68.6621k items/s
```