### PR TITLE
Support empty constrains on RCPrf.

### DIFF
--- a/src/include/sse/crypto/rcprf.hpp
+++ b/src/include/sse/crypto/rcprf.hpp
@@ -1090,7 +1090,7 @@ public:
             elements)
     {
         if (elements.empty()) {
-            throw std::invalid_argument("Empty key elements vector");
+            return 0;
         }
         RCPrfParams::depth_type h = elements[0]->tree_height();
 
@@ -1143,10 +1143,13 @@ public:
         };
         std::sort(elements_.begin(), elements_.end(), MinComparator());
 
-        // check that the elements are consecutive
-        for (auto it = elements_.begin() + 1; it != elements_.end(); ++it) {
-            if ((*(it - 1))->max_leaf() + 1 != (*it)->min_leaf()) {
-                throw std::invalid_argument("Non consecutive elements");
+        // check that the elements are consecutive (if the elements_ array is
+        // non empty)
+        if (!is_empty()) {
+            for (auto it = elements_.begin() + 1; it != elements_.end(); ++it) {
+                if ((*(it - 1))->max_leaf() + 1 != (*it)->min_leaf()) {
+                    throw std::invalid_argument("Non consecutive elements");
+                }
             }
         }
     }
@@ -1188,17 +1191,37 @@ public:
     }
     /* LCOV_EXCL_STOP */
 
+    /// @brief Check if the constrain is empty (i.e. the range of supported
+    /// leaves is empty)
+    ///
+    bool is_empty() const
+    {
+        return elements_.empty();
+    }
+
     /// @brief Returns the minimum leaf index supported by the constrained
     /// RC-PRF.
+    ///
+    /// If the constrain is empty (the array of elements is empty), returns
+    /// UINT64_MAX.
+
     uint64_t min_leaf() const
     {
+        if (is_empty()) {
+            return UINT64_MAX;
+        }
         return elements_[0]->min_leaf();
     }
 
     /// @brief Returns the maximum leaf index supported by the constrained
     /// RC-PRF.
+    ///
+    /// If the constrain is empty (the array of elements is empty), returns 0.
     uint64_t max_leaf() const
     {
+        if (is_empty()) {
+            return 0;
+        }
         return elements_[elements_.size() - 1]->max_leaf();
     }
 

--- a/tests/test_rcprf.cpp
+++ b/tests/test_rcprf.cpp
@@ -350,6 +350,24 @@ TEST(rc_prf, reconstrain_exceptions)
                  std::out_of_range);
 }
 
+// Check the behavior of empty constrains
+TEST(rc_prf, empty_constrain)
+{
+    std::vector<std::unique_ptr<sse::crypto::ConstrainedRCPrfElement<16>>>
+        empty_vec;
+
+    sse::crypto::ConstrainedRCPrf<16> cprf(std::move(empty_vec));
+
+    EXPECT_TRUE(cprf.is_empty());
+    EXPECT_EQ(cprf.min_leaf(), UINT64_MAX);
+    EXPECT_EQ(cprf.max_leaf(), 0);
+
+    EXPECT_THROW(cprf.eval(0), std::out_of_range);
+    EXPECT_THROW(cprf.eval(1), std::out_of_range);
+    EXPECT_THROW(cprf.eval(UINT64_MAX - 1), std::out_of_range);
+    EXPECT_THROW(cprf.eval(UINT64_MAX), std::out_of_range);
+}
+
 // Exceptions raised by the constructors
 TEST(rc_prf, constructors_exceptions)
 {
@@ -419,12 +437,6 @@ TEST(rc_prf, constructors_exceptions)
 
 
     // Exceptions raised by the ConstrainedRCPrf constructor
-    std::vector<std::unique_ptr<sse::crypto::ConstrainedRCPrfElement<16>>>
-        empty_vec;
-
-    EXPECT_THROW(sse::crypto::ConstrainedRCPrf<16> cprf(std::move(empty_vec)),
-                 std::invalid_argument);
-
 
     std::vector<std::unique_ptr<sse::crypto::ConstrainedRCPrfElement<16>>>
         leaf_vec;


### PR DESCRIPTION
In the `master` branch, `ConstrainedRCPrf` objects do not support empty constrains, *i.e.* constrains such that the supported evaluation range is empty. This PR changes the `ConstrainedRCPrf` class so that the object can support (a.k.a. can be created with) empty ranges, yet cannot be evaluated.