### PR TITLE
Fix clang compilation warnings coming from OpenSSL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build_test
 build_bench
 bin
 static_analysis
+Ubuntu
 
 debug_crypto
 check

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "externals/googletest"]
 	path = externals/googletest
 	url = https://github.com/google/googletest.git
+[submodule "externals/cmake-flag-manager"]
+	path = externals/cmake-flag-manager
+	url = https://github.com/rbost/cmake-flag-manager.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,15 +81,12 @@ endif()
 
 save_compile_option(-Wmissing-include-dirs)
 save_compile_option(
-    # -Weffc++
+    # -Weffc++ # Weffc++ is too annoying on gcc
     -Wnon-virtual-dtor
     -Wold-style-cast
     -Woverloaded-virtual
     -Wctor-dtor-privacy
     -fno-rtti
-)
-save_compile_option(
-    -Wextra-semi
 )
 # save_compile_option(
     # -fstack-protector
@@ -103,11 +100,11 @@ save_compile_option(
     -Wcast-align
 )
 save_compile_option(LIST_NAME "Lib_Warnings"
-    -Weverything
-    -Wextra-semi
+    -Weverything # All Clang warnings
+    -Wextra-semi # Extra, unnecessary semicolumns
     -Wsign-conversion
     -Wconversion
-    -Wno-c++98-compat
+    -Wno-c++98-compat # No need to be C++98 compatible: we require C++11
     -Wno-c++98-compat-pedantic
     -Wno-error=padded
     -Wno-weak-vtables

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,12 @@ set(default_build_type "Debug")
 option(opensse_ENABLE_WALL "Enable all warnings" ON)
 option(opensse_ENABLE_WEXTRA "Enable extra warnings" ON)
 option(opensse_ENABLE_WSHADOW "Enable shadow warning" OFF)
-option(opensse_ENABLE_PEDANTIC "Enable pedantic warning" OFF)
+option(opensse_ENABLE_PEDANTIC "Enable pedantic warning" ON)
 option(opensse_ENABLE_WERROR "Make all warnings into errors" ON)
+option(opensse_ENABLE_BASIC_WARNINGS "Enable basic additional warnings" ON)
+option(
+    opensse_ENABLE_ADVANCED_WARNINGS "Enable advanced additional warnings" ON
+)
 option(
     opensse_OPTIMIZE_FOR_NATIVE_ARCH
     "Enable compiler optimizations for the native processor architecture (if available)"
@@ -79,43 +83,55 @@ if(opensse_OPTIMIZE_FOR_NATIVE_ARCH)
     save_compile_option(-march=native)
 endif()
 
-save_compile_option(-Wmissing-include-dirs)
-save_compile_option(
-    # -Weffc++ # Weffc++ is too annoying on gcc
-    -Wnon-virtual-dtor
-    -Wold-style-cast
-    -Woverloaded-virtual
-    -Wctor-dtor-privacy
-    -fno-rtti
-)
-# save_compile_option(
-    # -fstack-protector
-    # -Wstack-protector
-# )
-save_compile_option(
-    -Wunsafe-loop-optimizations
-    -Wuseless-cast
-    -Wformat=2
-    -Wcast-qual
-    -Wcast-align
-)
-save_compile_option(LIST_NAME "Lib_Warnings"
-    -Weverything # All Clang warnings
-    -Wextra-semi # Extra, unnecessary semicolumns
-    -Wsign-conversion
-    -Wconversion
-    -Wno-c++98-compat # No need to be C++98 compatible: we require C++11
-    -Wno-c++98-compat-pedantic
-    -Wno-error=padded
-    -Wno-weak-vtables
-    -Wno-documentation-unknown-command
-    -Wno-weak-template-vtables
-    -Wno-exit-time-destructors
-    -Wno-error=source-uses-openmp
-    -Wno-covered-switch-default
-    -Wno-unused-macros
-    -Wno-padded
-)
+if(opensse_ENABLE_BASIC_WARNINGS)
+
+    save_compile_option(
+        -Wmissing-include-dirs
+        -Wnon-virtual-dtor
+        -Wold-style-cast
+        -Woverloaded-virtual
+        -Wctor-dtor-privacy
+        -Wunsafe-loop-optimizations
+        -Wuseless-cast
+        -Wformat=2
+        -Wcast-qual
+        -Wcast-align
+    )
+    save_compile_option(
+        -fno-rtti
+        # -fstack-protector -Wstack-protector
+    )
+endif()
+
+if(opensse_ENABLE_ADVANCED_WARNINGS)
+    save_compile_option(
+        LIST_NAME "Lib_Warnings"
+        # -Weffc++ # Weffc++ is too annoying on gcc
+        -Wextra-semi # Extra, unnecessary semicolumns
+        # -Wsign-conversion # To be enabled
+        # -Wconversion # Extremely strict on gcc
+        -Wno-c++98-compat # No need to be C++98 compatible: we require C++11
+        -Wno-c++98-compat-pedantic
+        -Wno-error=padded
+        -Wno-error=source-uses-openmp
+        -Wno-unused-macros
+        -Wno-padded
+    )
+
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+
+        save_compile_option(
+            LIST_NAME
+            "Clang_Lib_Warnings"
+            -Weverything # All Clang warnings
+            -Wno-covered-switch-default
+            -Wno-exit-time-destructors
+            -Wno-weak-vtables
+            -Wno-weak-template-vtables
+            -Wno-documentation-unknown-command
+        )
+    endif()
+endif()
 
 # This might be redundant with what is done in the main source CMakeLists.txt
 # file: we will look for OpenSSL there too. Yet, sse_crypto's CMakeLists.txt
@@ -147,6 +163,7 @@ endif()
 add_subdirectory(src)
 target_apply_saved_options(sse_crypto)
 target_apply_saved_options(LIST_NAME "Lib_Warnings" sse_crypto)
+target_apply_saved_options(LIST_NAME "Clang_Lib_Warnings" sse_crypto)
 add_sanitizers(sse_crypto)
 add_coverage(sse_crypto)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(default_build_type "Debug")
 option(opensse_ENABLE_WALL "Enable all warnings" ON)
 option(opensse_ENABLE_WEXTRA "Enable extra warnings" ON)
 option(opensse_ENABLE_WSHADOW "Enable shadow warning" OFF)
-option(opensse_ENABLE_PEDANTIC "Enable pedantic warning" OFF)
+option(opensse_ENABLE_PEDANTIC "Enable pedantic warning" ON)
 option(opensse_ENABLE_WERROR "Make all warnings into errors" ON)
 option(
     opensse_OPTIMIZE_FOR_NATIVE_ARCH
@@ -82,7 +82,8 @@ endif()
 save_compile_option(-Wmissing-include-dirs)
 save_compile_option(-Wpsabi)
 save_compile_option(
-    -Weffc++
+    # -Weffc++
+    -Wnon-virtual-dtor
     -Wold-style-cast
     -Woverloaded-virtual
     -Wctor-dtor-privacy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,34 @@ save_compile_option(
 save_compile_option(
     -Wextra-semi
 )
+# save_compile_option(
+    # -fstack-protector
+    # -Wstack-protector
+# )
+save_compile_option(
+    -Wunsafe-loop-optimizations
+    -Wuseless-cast
+    -Wformat=2
+    -Wcast-qual
+    -Wcast-align
+)
+save_compile_option(LIST_NAME "Lib_Warnings"
+    -Weverything
+    -Wextra-semi
+    -Wsign-conversion
+    -Wconversion
+    -Wno-c++98-compat
+    -Wno-c++98-compat-pedantic
+    -Wno-error=padded
+    -Wno-weak-vtables
+    -Wno-documentation-unknown-command
+    -Wno-weak-template-vtables
+    -Wno-exit-time-destructors
+    -Wno-error=source-uses-openmp
+    -Wno-covered-switch-default
+    -Wno-unused-macros
+    -Wno-padded
+)
 
 # This might be redundant with what is done in the main source CMakeLists.txt
 # file: we will look for OpenSSL there too. Yet, sse_crypto's CMakeLists.txt
@@ -122,6 +150,7 @@ endif()
 
 add_subdirectory(src)
 target_apply_saved_options(sse_crypto)
+target_apply_saved_options(LIST_NAME "Lib_Warnings" sse_crypto)
 add_sanitizers(sse_crypto)
 add_coverage(sse_crypto)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,10 @@ save_compile_option(
     -Wold-style-cast
     -Woverloaded-virtual
     -Wctor-dtor-privacy
+    -fno-rtti
+)
+save_compile_option(
+    -Wextra-semi
 )
 
 # This might be redundant with what is done in the main source CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ if(opensse_ENABLE_PEDANTIC)
 endif()
 
 if(opensse_ENABLE_WERROR)
-    save_compile_option(-Werror)
+    save_compile_option(-Wno-error=unknown-pragmas -Werror)
 endif()
 
 if(opensse_OPTIMIZE_FOR_NATIVE_ARCH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,11 @@ list(
     APPEND
         CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/externals/sanitizers-cmake/cmake"
 )
-
+list(
+    APPEND
+        CMAKE_MODULE_PATH
+        "${CMAKE_SOURCE_DIR}/externals/cmake-flag-manager/cmake"
+)
 # Build in Debug mode by default
 set(default_build_type "Debug")
 
@@ -40,6 +44,8 @@ option(
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 
+include(FlagManager)
+
 # enable code coverage
 find_package(codecov)
 
@@ -50,52 +56,69 @@ find_package(Sanitizers)
 enable_testing()
 
 if(opensse_ENABLE_WALL)
-    check_cxx_compiler_flag("-Wall" COMPILER_OPT_WALL_SUPPORTED)
-    if(COMPILER_OPT_WALL_SUPPORTED)
-        add_compile_options(-Wall)
-    endif()
+    save_compile_option(-Wall)
 endif()
 
 if(opensse_ENABLE_WEXTRA)
-    check_cxx_compiler_flag("-Wextra" COMPILER_OPT_WEXTRA_SUPPORTED)
-    if(COMPILER_OPT_WEXTRA_SUPPORTED)
-        add_compile_options(-Wextra)
-    endif()
+    save_compile_option(-Wextra)
 endif()
 
 if(opensse_ENABLE_WSHADOW)
-    check_cxx_compiler_flag("-Wshadow" COMPILER_OPT_WSHADOW_SUPPORTED)
-    if(COMPILER_OPT_WEXTRA_SUPPORTED)
-        add_compile_options(-Wshadow)
-    endif()
+    save_compile_option(-Wshadow)
 endif()
 
 if(opensse_ENABLE_PEDANTIC)
-    check_cxx_compiler_flag("-pedantic" COMPILER_OPT_PEDANTIC_SUPPORTED)
-    if(COMPILER_OPT_WEXTRA_SUPPORTED)
-        add_compile_options(-pedantic)
-    endif()
+    save_compile_option(-pedantic)
 endif()
 
 if(opensse_ENABLE_WERROR)
-    check_cxx_compiler_flag("-Werror" COMPILER_OPT_WERROR_SUPPORTED)
-    if(COMPILER_OPT_WERROR_SUPPORTED)
-        add_compile_options(-Werror -Wno-error=unknown-pragmas)
-    endif()
+    save_compile_option(-Wno-error=unknown-pragmas -Werror)
 endif()
 
 if(opensse_OPTIMIZE_FOR_NATIVE_ARCH)
-    check_cxx_compiler_flag("-march=native" COMPILER_OPT_ARCH_NATIVE_SUPPORTED)
-    if(COMPILER_OPT_ARCH_NATIVE_SUPPORTED)
-        add_compile_options(-march=native)
-    endif()
+    save_compile_option(-march=native)
 endif()
 
-check_c_compiler_flag("-Wpsabi" WARNING_PSABI)
-if(WARNING_PSABI)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=psabi")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=psabi")
-endif()
+save_compile_option(-Wmissing-include-dirs)
+save_compile_option(
+    # -Weffc++
+    -Wnon-virtual-dtor
+    -Wold-style-cast
+    -Woverloaded-virtual
+    -Wctor-dtor-privacy
+    -fno-rtti
+)
+save_compile_option(
+    -Wextra-semi
+)
+# save_compile_option(
+    # -fstack-protector
+    # -Wstack-protector
+# )
+save_compile_option(
+    -Wunsafe-loop-optimizations
+    -Wuseless-cast
+    -Wformat=2
+    -Wcast-qual
+    -Wcast-align
+)
+save_compile_option(LIST_NAME "Lib_Warnings"
+    -Weverything
+    -Wextra-semi
+    -Wsign-conversion
+    -Wconversion
+    -Wno-c++98-compat
+    -Wno-c++98-compat-pedantic
+    -Wno-error=padded
+    -Wno-weak-vtables
+    -Wno-documentation-unknown-command
+    -Wno-weak-template-vtables
+    -Wno-exit-time-destructors
+    -Wno-error=source-uses-openmp
+    -Wno-covered-switch-default
+    -Wno-unused-macros
+    -Wno-padded
+)
 
 # This might be redundant with what is done in the main source CMakeLists.txt
 # file: we will look for OpenSSL there too. Yet, sse_crypto's CMakeLists.txt
@@ -125,12 +148,15 @@ if(NOT TARGET gtest)
 endif()
 
 add_subdirectory(src)
+target_apply_saved_options(sse_crypto)
+target_apply_saved_options(LIST_NAME "Lib_Warnings" sse_crypto)
 add_sanitizers(sse_crypto)
 add_coverage(sse_crypto)
 
 # Tests
 
 add_subdirectory(tests)
+target_apply_saved_options(check)
 add_sanitizers(check)
 add_coverage(check)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,11 @@ list(
     APPEND
         CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/externals/sanitizers-cmake/cmake"
 )
-
+list(
+    APPEND
+        CMAKE_MODULE_PATH
+        "${CMAKE_SOURCE_DIR}/externals/cmake-flag-manager/cmake"
+)
 # Build in Debug mode by default
 set(default_build_type "Debug")
 
@@ -40,6 +44,8 @@ option(
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 
+include(FlagManager)
+
 # enable code coverage
 find_package(codecov)
 
@@ -50,52 +56,37 @@ find_package(Sanitizers)
 enable_testing()
 
 if(opensse_ENABLE_WALL)
-    check_cxx_compiler_flag("-Wall" COMPILER_OPT_WALL_SUPPORTED)
-    if(COMPILER_OPT_WALL_SUPPORTED)
-        add_compile_options(-Wall)
-    endif()
+    save_compile_option(-Wall)
 endif()
 
 if(opensse_ENABLE_WEXTRA)
-    check_cxx_compiler_flag("-Wextra" COMPILER_OPT_WEXTRA_SUPPORTED)
-    if(COMPILER_OPT_WEXTRA_SUPPORTED)
-        add_compile_options(-Wextra)
-    endif()
+    save_compile_option(-Wextra)
 endif()
 
 if(opensse_ENABLE_WSHADOW)
-    check_cxx_compiler_flag("-Wshadow" COMPILER_OPT_WSHADOW_SUPPORTED)
-    if(COMPILER_OPT_WEXTRA_SUPPORTED)
-        add_compile_options(-Wshadow)
-    endif()
+    save_compile_option(-Wshadow)
 endif()
 
 if(opensse_ENABLE_PEDANTIC)
-    check_cxx_compiler_flag("-pedantic" COMPILER_OPT_PEDANTIC_SUPPORTED)
-    if(COMPILER_OPT_WEXTRA_SUPPORTED)
-        add_compile_options(-pedantic)
-    endif()
+    save_compile_option(-pedantic)
 endif()
 
 if(opensse_ENABLE_WERROR)
-    check_cxx_compiler_flag("-Werror" COMPILER_OPT_WERROR_SUPPORTED)
-    if(COMPILER_OPT_WERROR_SUPPORTED)
-        add_compile_options(-Werror -Wno-error=unknown-pragmas)
-    endif()
+    save_compile_option(-Werror)
 endif()
 
 if(opensse_OPTIMIZE_FOR_NATIVE_ARCH)
-    check_cxx_compiler_flag("-march=native" COMPILER_OPT_ARCH_NATIVE_SUPPORTED)
-    if(COMPILER_OPT_ARCH_NATIVE_SUPPORTED)
-        add_compile_options(-march=native)
-    endif()
+    save_compile_option(-march=native)
 endif()
 
-check_c_compiler_flag("-Wpsabi" WARNING_PSABI)
-if(WARNING_PSABI)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=psabi")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=psabi")
-endif()
+save_compile_option(-Wmissing-include-dirs)
+save_compile_option(-Wpsabi)
+save_compile_option(
+    -Weffc++
+    -Wold-style-cast
+    -Woverloaded-virtual
+    -Wctor-dtor-privacy
+)
 
 # This might be redundant with what is done in the main source CMakeLists.txt
 # file: we will look for OpenSSL there too. Yet, sse_crypto's CMakeLists.txt
@@ -125,18 +116,21 @@ if(NOT TARGET gtest)
 endif()
 
 add_subdirectory(src)
+target_apply_saved_options(sse_crypto)
 add_sanitizers(sse_crypto)
 add_coverage(sse_crypto)
 
 # Tests
 
 add_subdirectory(tests)
+target_apply_saved_options(check)
 add_sanitizers(check)
 add_coverage(check)
 
 # add_subdirectory(bench)
 
 add_subdirectory(fuzzing)
+
 
 if(OPENSSL_FOUND)
     add_executable(debug_tool EXCLUDE_FROM_ALL main.cpp)

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -22,6 +22,7 @@ function(add_fuzz_target target_name target_source)
         sanitizer_add_flags(${target_name} "libFuzzer" "libFuzzer")
 
         add_dependencies(fuzz ${target_name})
+        target_apply_saved_options(${target_name})
 
         if(libFuzzer_standalone_FLAG_DETECTED)
 
@@ -31,6 +32,7 @@ function(add_fuzz_target target_name target_source)
                 ${target_source}
                 ${ARGN}
             )
+            target_apply_saved_options(${target_name}_standalone)
 
             target_link_libraries(${target_name}_standalone OpenSSE::crypto)
             add_sanitizers(${target_name}_standalone)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,6 +105,12 @@ target_compile_features(
     cxx_lambdas
 )
 
+target_compile_features(
+    sse_crypto
+    PRIVATE
+    c_std_99
+)
+
 target_include_directories(
     sse_crypto
     PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,24 +63,7 @@ add_library(
     mbedtls/pk_wrap.c
     mbedtls/rsa.c
 )
-target_compile_options(
-    sse_crypto
-    PRIVATE
-        # -Weverything
-        # -Wextra-semi
-        # -Wsign-conversion
-        # -Wconversion
-        # -Wno-c++98-compat
-        # -Wno-c++98-compat-pedantic
-        # -Wno-error=padded
-        # -Wno-weak-vtables
-        # -Wno-documentation-unknown-command
-        # -Wno-weak-template-vtables
-        # -Wno-exit-time-destructors
-        # -Wno-error=source-uses-openmp
-        # -Wno-covered-switch-default
-        # -Wno-unused-macros
-)
+
 
 # Generate PIC for the library
 set_target_properties(sse_crypto PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,24 @@ add_library(
     mbedtls/pk_wrap.c
     mbedtls/rsa.c
 )
+target_compile_options(
+    sse_crypto
+    PRIVATE
+        # -Weverything
+        # -Wextra-semi
+        # -Wsign-conversion
+        # -Wconversion
+        # -Wno-c++98-compat
+        # -Wno-c++98-compat-pedantic
+        # -Wno-error=padded
+        # -Wno-weak-vtables
+        # -Wno-documentation-unknown-command
+        # -Wno-weak-template-vtables
+        # -Wno-exit-time-destructors
+        # -Wno-error=source-uses-openmp
+        # -Wno-covered-switch-default
+        # -Wno-unused-macros
+)
 
 # Generate PIC for the library
 set_target_properties(sse_crypto PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/src/include/sse/crypto/rcprf.hpp
+++ b/src/include/sse/crypto/rcprf.hpp
@@ -153,15 +153,20 @@ public:
     ///
     /// @brief Copy constructor
     ///
-    RCPrfBase(const RCPrfBase<NBYTES>& rcprf) noexcept = default;
+    RCPrfBase(const RCPrfBase<NBYTES>& rcprf) noexcept
+        : tree_height_(rcprf.tree_height_)
+    {
+    }
     /* LCOV_EXCL_STOP */
 
     ///
     /// @brief Destructor
     ///
-    virtual ~RCPrfBase() = default;
+    virtual ~RCPrfBase()
+    {
+    }
 
-    ///
+    //
     /// @brief Return the height of the represented tree
     ///
     inline depth_type tree_height() const
@@ -169,17 +174,30 @@ public:
         return tree_height_;
     }
 
+    ///
+    /// @brief Copy assignment operator
+    ///
+    /// @param base     The object to be copied
+    ///
+    RCPrfBase<NBYTES>& operator=(RCPrfBase<NBYTES>& base) noexcept
+    {
+        tree_height_ = base.tree_height_;
+        return *this;
+    }
+
 protected:
     ///
-    /// @brief Compute the direction of the root-to-leaf path at a given depth
+    /// @brief Compute the direction of the root-to-leaf path at a given
+    /// depth
     ///
-    /// When following the root-to-leaf path, return which of the left of the
-    /// right child of the node at the given depth we have to take next.
+    /// When following the root-to-leaf path, return which of the left of
+    /// the right child of the node at the given depth we have to take next.
     ///
     /// @param leaf         The leaf to go to from the tree's root
-    /// @param node_depth   The depth of the node on the root-to-leaf path (a 0
-    ///                     node-depth points to the root, a tree_height-1 depth
-    ///                     is the leaf).
+    /// @param node_depth   The depth of the node on the root-to-leaf path
+    /// (a 0
+    ///                     node-depth points to the root, a tree_height-1
+    ///                     depth is the leaf).
     ///
     /// @return             The child to go to in the root-to-leaf path.
     ///
@@ -1188,7 +1206,7 @@ public:
     ConstrainedRCPrf& operator=(ConstrainedRCPrf<NBYTES>&& cprf) noexcept
     {
         static_cast<RCPrfBase<NBYTES>&>(*this)
-            = std::move(static_cast<RCPrfBase<NBYTES>&&>(cprf));
+            = static_cast<RCPrfBase<NBYTES>&>(cprf);
         elements_ = std::move(cprf.elements_);
 
         return *this;

--- a/src/include/sse/crypto/rcprf.hpp
+++ b/src/include/sse/crypto/rcprf.hpp
@@ -379,7 +379,7 @@ public:
     /// height and spanning over the specified leaves range.
     ///
     /// @param height          The height of the tree.
-    /// @param subtree_height  The height of the subtree represented by the
+    /// @param st_height       The height of the subtree represented by the
     ///                        element.
     /// @param min             The minimum leaf index spanned by the
     /// subtree.
@@ -395,20 +395,20 @@ public:
     ///                                        minimum leaf index.
     ///
     ConstrainedRCPrfElement(RCPrfParams::depth_type height,
-                            RCPrfParams::depth_type subtree_height,
+                            RCPrfParams::depth_type st_height,
                             uint64_t                min,
                             uint64_t                max)
-        : RCPrfBase<NBYTES>(height), subtree_height_(subtree_height),
-          min_leaf_(min), max_leaf_(max)
+        : RCPrfBase<NBYTES>(height), subtree_height_(st_height), min_leaf_(min),
+          max_leaf_(max)
     {
-        if (subtree_height == 0) {
+        if (st_height == 0) {
             /* LCOV_EXCL_START */
             // already covered by the subclasses
             throw std::invalid_argument("Subtree height should be strictly "
                                         "larger than 0.");
             /* LCOV_EXCL_STOP */
         }
-        if (subtree_height >= this->tree_height()) {
+        if (st_height >= this->tree_height()) {
             throw std::invalid_argument(
                 "Subtree height is not smaller than the tree height");
         }
@@ -553,7 +553,7 @@ public:
     ///
     /// @param key             The value of the subtree's node. The key given as
     ///                        input is moved, and is invalidated.
-    /// @param subtree_height  The height of the subtree represented by the
+    /// @param st_height       The height of the subtree represented by the
     ///                        element.
     /// @param min             The minimum leaf index spanned by the subtree.
     /// @param max             The maximum leaf index spanned by the subtree.
@@ -567,13 +567,13 @@ public:
     ///
     ConstrainedRCPrfInnerElement(Key<RCPrfParams::kKeySize>&& key,
                                  RCPrfParams::depth_type      height,
-                                 RCPrfParams::depth_type      subtree_height,
+                                 RCPrfParams::depth_type      st_height,
                                  uint64_t                     min,
                                  uint64_t                     max)
-        : ConstrainedRCPrfElement<NBYTES>(height, subtree_height, min, max),
+        : ConstrainedRCPrfElement<NBYTES>(height, st_height, min, max),
           base_prg_(std::move(key))
     {
-        if (subtree_height <= 1) {
+        if (st_height <= 1) {
             throw std::invalid_argument("Subtree height should be strictly "
                                         "larger than 1 for an inner element.");
         }
@@ -588,7 +588,7 @@ public:
     /// @param subtree_prg     The Prg representing the subtree's root. The Prg
     ///                        object is moved by the constructor, and is
     ///                        invalidated.
-    /// @param subtree_height  The height of the subtree represented by the
+    /// @param st_height       The height of the subtree represented by the
     ///                        element.
     /// @param min             The minimum leaf index spanned by the subtree.
     /// @param max             The maximum leaf index spanned by the subtree.
@@ -602,13 +602,13 @@ public:
     ///
     ConstrainedRCPrfInnerElement(Prg&&                   subtree_prg,
                                  RCPrfParams::depth_type height,
-                                 RCPrfParams::depth_type subtree_height,
+                                 RCPrfParams::depth_type st_height,
                                  uint64_t                min,
                                  uint64_t                max)
-        : ConstrainedRCPrfElement<NBYTES>(height, subtree_height, min, max),
+        : ConstrainedRCPrfElement<NBYTES>(height, st_height, min, max),
           base_prg_(std::move(subtree_prg))
     {
-        if (subtree_height <= 1) {
+        if (st_height <= 1) {
             throw std::invalid_argument("Subtree height should be strictly "
                                         "larger than 1 for an inner element.");
         }

--- a/src/include/sse/crypto/rcprf.hpp
+++ b/src/include/sse/crypto/rcprf.hpp
@@ -162,9 +162,7 @@ public:
     ///
     /// @brief Destructor
     ///
-    virtual ~RCPrfBase()
-    {
-    }
+    virtual ~RCPrfBase() = default;
 
     //
     /// @brief Return the height of the represented tree
@@ -179,7 +177,7 @@ public:
     ///
     /// @param base     The object to be copied
     ///
-    RCPrfBase<NBYTES>& operator=(RCPrfBase<NBYTES>& base) noexcept
+    RCPrfBase<NBYTES>& operator=(const RCPrfBase<NBYTES>& base) noexcept
     {
         tree_height_ = base.tree_height_;
         return *this;

--- a/src/include/sse/crypto/rcprf.hpp
+++ b/src/include/sse/crypto/rcprf.hpp
@@ -311,7 +311,9 @@ std::array<uint8_t, NBYTES> RCPrfBase<NBYTES>::derive_leaf(
     depth_type base_depth,
     uint64_t   leaf) const
 {
-    assert(this->tree_height() > base_depth + 1);
+    assert(this->tree_height() >= 2); // this has to be an inner node
+    // with the previous check, we can substract 1 without risking an underflow
+    assert(this->tree_height() - 1 > base_depth);
 
     if (this->tree_height() == base_depth + 2) {
         // only one derivation to do
@@ -325,7 +327,9 @@ std::array<uint8_t, NBYTES> RCPrfBase<NBYTES>::derive_leaf(
         return result;
     }
 
-    assert(this->tree_height() - base_depth > 2);
+    // the previous test ensures that the tree_height is >= 2
+    assert(this->tree_height() - 2 > base_depth);
+
     // the first step is done from the base PRG
     RCPrfTreeNodeChild child = get_child(leaf, base_depth);
     Key<kKeySize>      subkey

--- a/src/mbedtls/rsa_io.c
+++ b/src/mbedtls/rsa_io.c
@@ -149,7 +149,7 @@ int mbedtls_rsa_write_pubkey_der( mbedtls_rsa_context *key, unsigned char *buf, 
 //            return( ret );
 //        }
 
-    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_algorithm_identifier( &c, buf, (char*)oid, oid_len,
+    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_algorithm_identifier( &c, buf, (const char*)oid, oid_len,
                                                                        par_len ) );
     
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( &c, buf, len ) );

--- a/src/mbedtls/rsa_io.c
+++ b/src/mbedtls/rsa_io.c
@@ -122,7 +122,7 @@ int mbedtls_rsa_write_pubkey_der( mbedtls_rsa_context *key, unsigned char *buf, 
     //#warning WORKAROUND
     // we want to avoid using the oid functions, so the oid is hardcoded here
     size_t oid_len = 9;
-    const char oid[10] = {0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, '\0'};
+    const unsigned char oid[10] = {0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, '\0'};
     
     c = buf + size;
     
@@ -149,7 +149,7 @@ int mbedtls_rsa_write_pubkey_der( mbedtls_rsa_context *key, unsigned char *buf, 
 //            return( ret );
 //        }
 
-    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_algorithm_identifier( &c, buf, oid, oid_len,
+    MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_algorithm_identifier( &c, buf, (char*)oid, oid_len,
                                                                        par_len ) );
     
     MBEDTLS_ASN1_CHK_ADD( len, mbedtls_asn1_write_len( &c, buf, len ) );

--- a/src/ppke/GMPpke.cpp
+++ b/src/ppke/GMPpke.cpp
@@ -294,9 +294,9 @@ GmppkePrivateKeyShare Gmppke::skShareGen(
 
     const ZR l_d = group.pseudoRandomZR(prf, ("param_l_" + d_string));
     const ZR l_d_1
-        = (d > 1) ? (group.pseudoRandomZR(
-                        prf, std::string("param_l_" + std::to_string(d - 1))))
-                  : (-sp.alpha);
+        = (d > 1)
+              ? (group.pseudoRandomZR(prf, "param_l_" + std::to_string(d - 1)))
+              : (-sp.alpha);
 
     share.sk1 = group.exp(group.generatorG2(), sp.beta * (l_d - l_d_1 + r1));
     share.sk3 = group.exp(group.generatorG2(), r1);          // g^r

--- a/src/ppke/GMPpke.hpp
+++ b/src/ppke/GMPpke.hpp
@@ -76,13 +76,12 @@ public:
 class Gmppke;
 class PartialGmmppkeCT;
 class GmppkePrivateKey;
-class GmppkePublicKey : public virtual baseKey
+class GmppkePublicKey : public baseKey
 {
 public:
     friend bool operator==(const GmppkePublicKey& x, const GmppkePublicKey& y)
     {
-        return (dynamic_cast<const baseKey&>(x)
-                    == dynamic_cast<const baseKey&>(y)
+        return (static_cast<const baseKey&>(x) == static_cast<const baseKey&>(y)
                 && x.ppkeg1 == y.ppkeg1 && x.gqofxG1 == y.gqofxG1
                 && x.gqofxG2 == y.gqofxG2);
     }
@@ -277,8 +276,8 @@ protected:
     friend bool operator==(const GmmppkeCT<T>& x, const GmmppkeCT<T>& y)
     {
         return x.ct1 == y.ct1
-               && dynamic_cast<const PartialGmmppkeCT&>(x)
-                      == dynamic_cast<const PartialGmmppkeCT&>(y);
+               && static_cast<const PartialGmmppkeCT&>(x)
+                      == static_cast<const PartialGmmppkeCT&>(y);
     }
     friend bool operator!=(const GmmppkeCT<T>& x, const GmmppkeCT<T>& y)
     {

--- a/src/prp.cpp
+++ b/src/prp.cpp
@@ -67,9 +67,8 @@ Key<sizeof(aez_ctx_t)> Prp::init_random_aez_ctx()
     }
     auto callback = [](uint8_t* key_content) {
         Key<Prp::kKeySize> r_key;
-        aez_setup(static_cast<const unsigned char*>(r_key.unlock_get()),
-                  48,
-                  reinterpret_cast<aez_ctx_t*>(key_content));
+        aez_setup(
+            r_key.unlock_get(), 48, reinterpret_cast<aez_ctx_t*>(key_content));
     };
 
     return Key<Prp::kContextSize>(callback);
@@ -90,9 +89,8 @@ Key<sizeof(aez_ctx_t)> Prp::init_aez_ctx(Key<kKeySize>&& k)
         /* LCOV_EXCL_STOP */
     }
     auto callback = [&k](uint8_t* key_content) {
-        aez_setup(static_cast<const unsigned char*>(k.unlock_get()),
-                  48,
-                  reinterpret_cast<aez_ctx_t*>(key_content));
+        aez_setup(
+            k.unlock_get(), 48, reinterpret_cast<aez_ctx_t*>(key_content));
     };
 
     auto key = Key<Prp::kContextSize>(callback);

--- a/src/tdp_impl/tdp_impl_mbedtls.cpp
+++ b/src/tdp_impl/tdp_impl_mbedtls.cpp
@@ -130,8 +130,9 @@ std::string TdpImpl_mbedTLS::public_key() const
     int           ret;
     unsigned char buf[5000];
 
+    // we don't need the const_cast as rsa_key_ is declared mutable
     ret = mbedtls_rsa_write_pubkey_pem(
-        const_cast<mbedtls_rsa_context*>(&rsa_key_), buf, sizeof(buf));
+        /*const_cast<mbedtls_rsa_context*>*/ (&rsa_key_), buf, sizeof(buf));
 
     if (ret != 0) {
         throw std::runtime_error(

--- a/src/tdp_impl/tdp_impl_mbedtls.hpp
+++ b/src/tdp_impl/tdp_impl_mbedtls.hpp
@@ -76,6 +76,8 @@ public:
 protected:
     TdpImpl_mbedTLS();
 
+    // mbedTLS APIs don't seem to be really const-correct.
+    // for the moment, use a mutable member instead of const_cast everywhere
     mutable mbedtls_rsa_context rsa_key_;
 };
 

--- a/src/tdp_impl/tdp_impl_openssl.cpp
+++ b/src/tdp_impl/tdp_impl_openssl.cpp
@@ -504,7 +504,7 @@ std::array<uint8_t, TdpImpl_OpenSSL::kMessageSpaceSize> TdpInverseImpl_OpenSSL::
     std::array<uint8_t, TdpImpl_OpenSSL::kMessageSpaceSize> out;
 
     RSA_private_decrypt(static_cast<int>(in.size()),
-                        static_cast<const unsigned char*>(in.data()),
+                        in.data(),
                         out.data(),
                         get_rsa_key(),
                         RSA_NO_PADDING);
@@ -662,7 +662,7 @@ TdpMultPoolImpl_OpenSSL::eval_pool(
     if (order == 1) {
         // regular eval
         RSA_public_encrypt(static_cast<int>(in.size()),
-                           static_cast<const unsigned char*>(in.data()),
+                           in.data(),
                            out.data(),
                            get_rsa_key(),
                            RSA_NO_PADDING);
@@ -670,7 +670,7 @@ TdpMultPoolImpl_OpenSSL::eval_pool(
     } else if (order <= maximum_order()) {
         // get the right RSA context, i.e. the one in keys_[order-1]
         RSA_public_encrypt(static_cast<int>(in.size()),
-                           static_cast<const unsigned char*>(in.data()),
+                           in.data(),
                            out.data(),
                            keys_[order - 2],
                            RSA_NO_PADDING);

--- a/src/tdp_impl/tdp_impl_openssl.cpp
+++ b/src/tdp_impl/tdp_impl_openssl.cpp
@@ -481,9 +481,9 @@ void TdpInverseImpl_OpenSSL::invert(const std::string& in,
                                     std::string&       out) const
 {
     int           ret;
-    unsigned char rsa_out[rsa_size()];
+    unsigned char rsa_out[kMessageSpaceSize];
 
-    if (in.size() != rsa_size()) {
+    if (in.size() != kMessageSpaceSize) {
         throw std::invalid_argument("Invalid TDP input size. Input size should "
                                     "be kMessageSpaceSize bytes long.");
     }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -25,6 +25,8 @@
 
 #include <pthread.h>
 
+#include <thread>
+
 #include <sodium/core.h>
 
 #ifdef WITH_OPENSSL
@@ -65,8 +67,9 @@ static void locking_function(int                                 mode,
 // NOLINTNEXTLINE(google-runtime-int)
 static unsigned long id_function()
 {
-    // NOLINTNEXTLINE(google-runtime-int)
-    return pthread_self();
+    std::thread::id tid = std::this_thread::get_id();
+
+    return std::hash<std::thread::id>()(tid);
 }
 
 // No multithreaded test is performed, hence no lock is used.

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -44,7 +44,6 @@ static pthread_mutex_t* mutex_buf = nullptr;
  * @param    n        lock number
  * @param    file    source file name
  * @param    line    source file line number
- * @return    none
  */
 static void locking_function(int                                 mode,
                              int                                 n,
@@ -106,7 +105,6 @@ err:
  * @param    l        lock structure pointer
  * @param    file    source file name
  * @param    line    source file line number
- * @return    none
  */
 static void dyn_lock_function(int                                 mode,
                               struct CRYPTO_dynlock_value*        l,
@@ -126,7 +124,6 @@ static void dyn_lock_function(int                                 mode,
  * @param    l        lock structure pointer
  * @param    file    source file name
  * @param    line    source file line number
- * @return    none
  */
 
 static void dyn_destroy_function(struct CRYPTO_dynlock_value*        l,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -67,7 +67,7 @@ static void locking_function(int                                 mode,
 static unsigned long id_function()
 {
     // NOLINTNEXTLINE(google-runtime-int)
-    return reinterpret_cast<unsigned long>(pthread_self());
+    return pthread_self();
 }
 
 // No multithreaded test is performed, hence no lock is used.

--- a/tests/encryption.cpp
+++ b/tests/encryption.cpp
@@ -50,7 +50,7 @@ TEST(encryption, correctness)
     sse::crypto::Cipher cipher(sse::crypto::Key<kCipherKeySize>(k.data()));
     cipher.encrypt(in_enc, out_enc);
 
-    string in_dec = string(out_enc);
+    string in_dec = out_enc;
 
     cipher.decrypt(in_dec, out_dec);
 

--- a/tests/hashing.cpp
+++ b/tests/hashing.cpp
@@ -49,7 +49,7 @@ TEST(sha_512, test_vector_1)
     sse::crypto::hash::sha512::hash(
         reinterpret_cast<const unsigned char*>(in.data()),
         in.length(),
-        reinterpret_cast<unsigned char*>(out.data()));
+        out.data());
 
     uint8_t reference[]
         = {0xdd, 0xaf, 0x35, 0xa1, 0x93, 0x61, 0x7a, 0xba, 0xcc, 0x41, 0x73,
@@ -76,7 +76,7 @@ TEST(sha_512, test_vector_2)
     sse::crypto::hash::sha512::hash(
         reinterpret_cast<const unsigned char*>(in.data()),
         in.length(),
-        reinterpret_cast<unsigned char*>(out.data()));
+        out.data());
 
     uint8_t reference[]
         = {0xcf, 0x83, 0xe1, 0x35, 0x7e, 0xef, 0xb8, 0xbd, 0xf1, 0x54, 0x28,
@@ -102,7 +102,7 @@ TEST(sha_512, test_vector_3)
     sse::crypto::hash::sha512::hash(
         reinterpret_cast<const unsigned char*>(in.data()),
         in.length(),
-        reinterpret_cast<unsigned char*>(out.data()));
+        out.data());
 
     uint8_t reference[]
         = {0x20, 0x4a, 0x8f, 0xc6, 0xdd, 0xa8, 0x2f, 0x0a, 0x0c, 0xed, 0x7b,
@@ -129,7 +129,7 @@ TEST(sha_512, test_vector_4)
     sse::crypto::hash::sha512::hash(
         reinterpret_cast<const unsigned char*>(in.data()),
         in.length(),
-        reinterpret_cast<unsigned char*>(out.data()));
+        out.data());
 
     uint8_t reference[]
         = {0x8e, 0x95, 0x9b, 0x75, 0xda, 0xe3, 0x13, 0xda, 0x8c, 0xf4, 0xf7,
@@ -155,7 +155,7 @@ TEST(sha_512, test_vector_5)
     sse::crypto::hash::sha512::hash(
         reinterpret_cast<const unsigned char*>(in.data()),
         in.length(),
-        reinterpret_cast<unsigned char*>(out.data()));
+        out.data());
 
     uint8_t reference[]
         = {0xe7, 0x18, 0x48, 0x3d, 0x0c, 0xe7, 0x69, 0x64, 0x4e, 0x2e, 0x42,

--- a/tests/hashing.cpp
+++ b/tests/hashing.cpp
@@ -183,7 +183,7 @@ TEST(blake2, blake2b)
     uint8_t hash[HASH_LENGTH] = {0};
 
     for (size_t i = 0; i < sizeof(in); ++i) {
-        in[i] = i;
+        in[i] = static_cast<uint8_t>(i);
     }
 
     for (size_t i = 0; i < sizeof(in); ++i) {

--- a/tests/test_mbedtls.cpp
+++ b/tests/test_mbedtls.cpp
@@ -458,7 +458,9 @@ TEST(mbedTLS, key_serialization_compat_mbedtls2openssl)
 
         // create the OpenSSL key from the buffer
         mem = BIO_new_mem_buf(
-            buf, (int)strnlen(reinterpret_cast<const char*>(buf), sizeof(buf)));
+            buf,
+            static_cast<int>(
+                strnlen(reinterpret_cast<const char*>(buf), sizeof(buf))));
         evpkey = PEM_read_bio_PrivateKey(mem, NULL, NULL, NULL);
 
         ASSERT_FALSE(evpkey == NULL);
@@ -486,7 +488,9 @@ TEST(mbedTLS, key_serialization_compat_mbedtls2openssl)
 
         // create the OpenSSL key from the buffer
         mem = BIO_new_mem_buf(
-            buf, (int)strnlen(reinterpret_cast<const char*>(buf), sizeof(buf)));
+            buf,
+            static_cast<int>(
+                strnlen(reinterpret_cast<const char*>(buf), sizeof(buf))));
         openssl_pk_rsa = PEM_read_bio_RSA_PUBKEY(mem, NULL, NULL, NULL);
         ASSERT_FALSE(openssl_pk_rsa == NULL);
 
@@ -540,7 +544,7 @@ TEST(mbedTLS, key_serialization_compat_openssl2mbedtls)
         size_t len = BIO_ctrl_pending(bio);
         ASSERT_LE(len + 1, sizeof(buf));
 
-        ASSERT_NE(BIO_read(bio, buf, (int)len), 0);
+        ASSERT_NE(BIO_read(bio, buf, static_cast<int>(len)), 0);
 
         EVP_PKEY_free(evpkey);
 
@@ -576,7 +580,7 @@ TEST(mbedTLS, key_serialization_compat_openssl2mbedtls)
         len = BIO_ctrl_pending(bio);
         ASSERT_LE(len + 1, sizeof(buf));
 
-        ASSERT_NE(BIO_read(bio, buf, (int)len), 0);
+        ASSERT_NE(BIO_read(bio, buf, static_cast<int>(len)), 0);
 
         BIO_free_all(bio);
 

--- a/tests/test_ppke.cpp
+++ b/tests/test_ppke.cpp
@@ -322,13 +322,10 @@ TEST(relic, arithmetic_ZR)
         ASSERT_EQ(z3 << 3, z3 * relicxx::ZR(8));
         ASSERT_EQ(z4 << 4, z4 * relicxx::ZR(16));
 
-        ASSERT_EQ(group.exp(z1, static_cast<int>(42)),
-                  group.exp(z1, relicxx::ZR(42)));
-        ASSERT_EQ(group.exp(z2, static_cast<int>(10)),
-                  group.exp(z2, relicxx::ZR(10)));
-        ASSERT_EQ(group.exp(z3, static_cast<int>(4675)),
-                  group.exp(z3, relicxx::ZR(4675)));
-        ASSERT_EQ(group.exp(z4, static_cast<int>(233453451)),
+        ASSERT_EQ(group.exp(z1, 42), group.exp(z1, relicxx::ZR(42)));
+        ASSERT_EQ(group.exp(z2, 10), group.exp(z2, relicxx::ZR(10)));
+        ASSERT_EQ(group.exp(z3, 4675), group.exp(z3, relicxx::ZR(4675)));
+        ASSERT_EQ(group.exp(z4, 233453451),
                   group.exp(z4, relicxx::ZR(233453451)));
     }
 }
@@ -353,13 +350,10 @@ TEST(relic, arithmetic_G1)
         ASSERT_EQ(group.div(z1, z2), group.mul(group.inv(z2), z1));
         ASSERT_EQ(group.div(z2, z1), group.inv(group.div(z1, z2)));
 
-        ASSERT_EQ(group.exp(z1, static_cast<int>(42)),
-                  group.exp(z1, relicxx::ZR(42)));
-        ASSERT_EQ(group.exp(z2, static_cast<int>(10)),
-                  group.exp(z2, relicxx::ZR(10)));
-        ASSERT_EQ(group.exp(z3, static_cast<int>(4675)),
-                  group.exp(z3, relicxx::ZR(4675)));
-        ASSERT_EQ(group.exp(z4, static_cast<int>(233453451)),
+        ASSERT_EQ(group.exp(z1, 42), group.exp(z1, relicxx::ZR(42)));
+        ASSERT_EQ(group.exp(z2, 10), group.exp(z2, relicxx::ZR(10)));
+        ASSERT_EQ(group.exp(z3, 4675), group.exp(z3, relicxx::ZR(4675)));
+        ASSERT_EQ(group.exp(z4, 233453451),
                   group.exp(z4, relicxx::ZR(233453451)));
     }
 }
@@ -383,13 +377,10 @@ TEST(relic, arithmetic_G2)
         ASSERT_EQ(group.div(z1, z2), group.mul(group.inv(z2), z1));
         ASSERT_EQ(group.div(z2, z1), group.inv(group.div(z1, z2)));
 
-        ASSERT_EQ(group.exp(z1, static_cast<int>(42)),
-                  group.exp(z1, relicxx::ZR(42)));
-        ASSERT_EQ(group.exp(z2, static_cast<int>(10)),
-                  group.exp(z2, relicxx::ZR(10)));
-        ASSERT_EQ(group.exp(z3, static_cast<int>(4675)),
-                  group.exp(z3, relicxx::ZR(4675)));
-        ASSERT_EQ(group.exp(z4, static_cast<int>(233453451)),
+        ASSERT_EQ(group.exp(z1, 42), group.exp(z1, relicxx::ZR(42)));
+        ASSERT_EQ(group.exp(z2, 10), group.exp(z2, relicxx::ZR(10)));
+        ASSERT_EQ(group.exp(z3, 4675), group.exp(z3, relicxx::ZR(4675)));
+        ASSERT_EQ(group.exp(z4, 233453451),
                   group.exp(z4, relicxx::ZR(233453451)));
     }
 }
@@ -410,13 +401,10 @@ TEST(relic, arithmetic_GT)
         ASSERT_EQ(group.div(z1, z2), group.mul(group.inv(z2), z1));
         ASSERT_EQ(group.div(z2, z1), group.inv(group.div(z1, z2)));
 
-        ASSERT_EQ(group.exp(z1, static_cast<int>(42)),
-                  group.exp(z1, relicxx::ZR(42)));
-        ASSERT_EQ(group.exp(z2, static_cast<int>(10)),
-                  group.exp(z2, relicxx::ZR(10)));
-        ASSERT_EQ(group.exp(z3, static_cast<int>(4675)),
-                  group.exp(z3, relicxx::ZR(4675)));
-        ASSERT_EQ(group.exp(z4, static_cast<int>(233453451)),
+        ASSERT_EQ(group.exp(z1, 42), group.exp(z1, relicxx::ZR(42)));
+        ASSERT_EQ(group.exp(z2, 10), group.exp(z2, relicxx::ZR(10)));
+        ASSERT_EQ(group.exp(z3, 4675), group.exp(z3, relicxx::ZR(4675)));
+        ASSERT_EQ(group.exp(z4, 233453451),
                   group.exp(z4, relicxx::ZR(233453451)));
     }
 }

--- a/tests/test_ppke.cpp
+++ b/tests/test_ppke.cpp
@@ -636,7 +636,7 @@ TEST(puncturable, correctness)
 {
     std::array<uint8_t, 32> master_key;
     for (size_t i = 0; i < master_key.size(); i++) {
-        master_key[i] = 1 << i;
+        master_key[i] = static_cast<uint8_t>(5 * i);
     }
 
     sse::crypto::punct::master_key_type key(master_key.data());

--- a/tests/test_prg.cpp
+++ b/tests/test_prg.cpp
@@ -217,6 +217,9 @@ void prg_test_key_derivation_consistency()
     }
 
     constexpr size_t n_derived_keys_max = TEST_COUNT + 1;
+    static_assert(n_derived_keys_max <= UINT16_MAX,
+                  "The number of derived keys is too large");
+
 
     for (size_t i = 0; i < TEST_COUNT; i++) {
         sse::crypto::random_bytes(k);
@@ -225,9 +228,9 @@ void prg_test_key_derivation_consistency()
         k_cp3 = k;
         k_cp4 = k;
 
-        constexpr size_t derived_key_size = K_SIZE;
-        size_t           n_derived_keys   = i + 1;
-        constexpr size_t key_offset       = 3;
+        constexpr size_t   derived_key_size = K_SIZE;
+        uint16_t           n_derived_keys   = static_cast<uint16_t>(i + 1);
+        constexpr uint16_t key_offset       = 3;
 
         std::array<uint8_t,
                    (n_derived_keys_max + key_offset) * derived_key_size>
@@ -257,7 +260,7 @@ void prg_test_key_derivation_consistency()
         sse::crypto::Prg::derive(
             sse::crypto::Key<kPrgKeySize>(k_cp2.data()), 0, out);
 
-        for (size_t j = 0; j < n_derived_keys; j++) {
+        for (uint16_t j = 0; j < n_derived_keys; j++) {
             k_loc = k_cp4;
 
             key_vec[j].unlock();

--- a/tests/test_prp.cpp
+++ b/tests/test_prp.cpp
@@ -70,8 +70,10 @@ TEST(prp, consistency_32)
         std::string out_32_s_1
             = fpe.encrypt(std::string(arr_32.begin(), arr_32.end()));
         std::string out_32_s_2;
-        uint32_t    in_32_i = arr_32[0] + (arr_32[1] << 8) + (arr_32[2] << 16)
-                           + (arr_32[3] << 24);
+        uint32_t    in_32_i = static_cast<uint32_t>(arr_32[0])
+                           + (static_cast<uint32_t>(arr_32[1]) << 8UL)
+                           + (static_cast<uint32_t>(arr_32[2]) << 16UL)
+                           + (static_cast<uint32_t>(arr_32[3]) << 24UL);
 
         fpe.encrypt(std::string(arr_32.begin(), arr_32.end()), out_32_s_2);
         uint32_t out_32_i = fpe.encrypt(in_32_i);

--- a/tests/test_prp.cpp
+++ b/tests/test_prp.cpp
@@ -46,7 +46,7 @@ TEST(prp, correctness)
 
         ASSERT_EQ(in_enc.length(), out_enc.length());
 
-        string in_dec = string(out_enc);
+        string in_dec = out_enc;
 
         fpe.decrypt(in_dec, out_dec);
 
@@ -155,13 +155,13 @@ TEST(prp, wrapping)
         ASSERT_EQ(in_enc.length(), out_enc2.length());
         EXPECT_EQ(out_enc1, out_enc2);
 
-        string in_dec = string(out_enc1);
+        string in_dec = out_enc1;
         base_prp.decrypt(in_dec, out_dec);
 
         ASSERT_EQ(in_dec.length(), out_dec.length());
         ASSERT_EQ(in_enc, out_dec);
 
-        in_dec = string(out_enc2);
+        in_dec = out_enc2;
         base_prp.decrypt(in_dec, out_dec);
 
         ASSERT_EQ(in_dec.length(), out_dec.length());

--- a/tests/test_rcprf.cpp
+++ b/tests/test_rcprf.cpp
@@ -35,7 +35,7 @@ TEST(rc_prf, parameters)
 {
     // leaf count
     EXPECT_EQ(sse::crypto::RCPrfParams::max_leaf_index(0), 0);
-    constexpr sse::crypto::RCPrfParams::depth_type max_depth = ~0;
+    constexpr sse::crypto::RCPrfParams::depth_type max_depth = 0xFF;
     for (sse::crypto::RCPrfParams::depth_type i
          = sse::crypto::RCPrfParams::kMaxHeight;
          i < max_depth;

--- a/tests/test_tdp.cpp
+++ b/tests/test_tdp.cpp
@@ -363,7 +363,7 @@ static void test_tdp_impl_multiple_eval(const size_t string_test_count,
 
         string v1, v2, v3;
         v2 = sample;
-        for (size_t j = 1; j < pool.maximum_order(); j++) {
+        for (uint8_t j = 1; j < pool.maximum_order(); j++) {
             v1 = tdp_test::tdp_eval_pool(pool, sample, j);
             tdp_inv.eval(v2, v2);
             tdp_test::tdp_eval_pool(pool, sample, v3, j);
@@ -396,7 +396,7 @@ static void test_tdp_impl_multiple_eval(const size_t string_test_count,
 
         string                                                      v1;
         std::array<uint8_t, sse::crypto::TdpMultPool::kMessageSize> v2;
-        for (size_t j = 1; j < pool.maximum_order(); j++) {
+        for (uint8_t j = 1; j < pool.maximum_order(); j++) {
             tdp_test::tdp_eval_pool(pool, sample, v1, j);
             v2 = tdp_test::tdp_eval_pool(pool, sample_arr, j);
 


### PR DESCRIPTION
Enable new warnings by default.
Fix the newly found errors.