### PR TITLE
Fix compilation errors in the code based on Relic

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -105,10 +105,6 @@ target_include_directories(
 
 target_link_libraries(sse_crypto sodium ${RLC_LIBRARY})
 
-
-message(STATUS "RELIC1 : ${RLC_LIBRARY}")
-message(STATUS "RELIC2 : ${RLC_LIBRARIES}")
-
 if(OPENSSL_FOUND)
     target_link_libraries(sse_crypto OpenSSL::Crypto)
     if(RSA_IMPL_OPENSSL)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,7 +103,11 @@ target_include_directories(
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/sse/crypto
 )
 
-target_link_libraries(sse_crypto sodium ${RELIC_LIBRARIES})
+target_link_libraries(sse_crypto sodium ${RLC_LIBRARY})
+
+
+message(STATUS "RELIC1 : ${RLC_LIBRARY}")
+message(STATUS "RELIC2 : ${RLC_LIBRARIES}")
 
 if(OPENSSL_FOUND)
     target_link_libraries(sse_crypto OpenSSL::Crypto)

--- a/src/ppke/GMPpke.hpp
+++ b/src/ppke/GMPpke.hpp
@@ -29,7 +29,7 @@ constexpr static size_t kPPKEPrfOutputSize
     = relicxx::PairingGroup::kPrfOutputSize;
 
 // cppcheck-suppress constStatement
-using PPKE_HKDF = sse::crypto::HMac<sse::crypto::Hash, 12 * FP_BYTES>;
+using PPKE_HKDF = sse::crypto::HMac<sse::crypto::Hash, 12 * RLC_FP_BYTES>;
 
 using tag_type = std::array<uint8_t, kTagSize>;
 
@@ -339,7 +339,7 @@ public:
         sse::crypto::HMac<sse::crypto::Hash, kTagSize> hkdf(
             sse::crypto::Key<kTagSize>(arr.data()));
 
-        std::array<uint8_t, 12 * FP_BYTES> gt_blind_bytes;
+        std::array<uint8_t, 12 * RLC_FP_BYTES> gt_blind_bytes;
         group.exp(group.pair(pk.g2G1, pk.ppkeg1), s)
             .getBytes(false, gt_blind_bytes.size(), gt_blind_bytes.data());
 
@@ -365,7 +365,7 @@ public:
         sse::crypto::HMac<sse::crypto::Hash, kTagSize> hkdf(
             sse::crypto::Key<kTagSize>(arr.data()));
 
-        std::array<uint8_t, 12 * FP_BYTES> gt_blind_bytes;
+        std::array<uint8_t, 12 * RLC_FP_BYTES> gt_blind_bytes;
         group.exp(group.generatorGT(), sp.alpha * sp.beta * s)
             .getBytes(false, gt_blind_bytes.size(), gt_blind_bytes.data());
 

--- a/src/ppke/relic_wrapper/common.h
+++ b/src/ppke/relic_wrapper/common.h
@@ -85,8 +85,8 @@ enum Other_type
     gt_null(g);                                                                \
     gt_new(g);
 
-#define FP_STR (((((FP_BYTES * 2 + 1)))))
-#define G1_LEN ((((((FP_BYTES * 2) + 2)))))
+#define FP_STR (((((RLC_FP_BYTES * 2 + 1)))))
+#define G1_LEN ((((((RLC_FP_BYTES * 2) + 2)))))
 /* KSS_P508 */
 #define G2_LEN G1_LEN
 #define GT_LEN G1_LEN

--- a/src/ppke/relic_wrapper/relic_api.cpp
+++ b/src/ppke/relic_wrapper/relic_api.cpp
@@ -31,7 +31,7 @@ static void invertZR(ZR& c, const ZR& a, const bn_t order)
     bn_inits(s);
     // compute c = (1 / a) mod n
     bn_gcd_ext(s, c.z, nullptr, a1.z, order);
-    if (bn_sign(c.z) == BN_NEG) {
+    if (bn_sign(c.z) == RLC_NEG) {
         bn_add(c.z, c.z, order);
     }
     bn_free(s);
@@ -101,7 +101,7 @@ ZR operator-(const ZR& x, const ZR& y)
     ZR zr;
 
     bn_sub(zr.z, x.z, y.z);
-    if (bn_sign(zr.z) == BN_NEG) {
+    if (bn_sign(zr.z) == RLC_NEG) {
         bn_add(zr.z, zr.z, zr.order);
     } else {
         bn_mod(zr.z, zr.z, zr.order);
@@ -113,7 +113,7 @@ ZR operator-(const ZR& x)
 {
     ZR zr;
     bn_neg(zr.z, x.z);
-    if (bn_sign(zr.z) == BN_NEG) {
+    if (bn_sign(zr.z) == RLC_NEG) {
         bn_add(zr.z, zr.z, zr.order);
     }
     return zr;
@@ -124,7 +124,7 @@ ZR operator*(const ZR& x, const ZR& y)
 {
     ZR zr;
     bn_mul(zr.z, x.z, y.z);
-    if (bn_sign(zr.z) == BN_NEG) {
+    if (bn_sign(zr.z) == RLC_NEG) {
         bn_add(zr.z, zr.z, zr.order);
     } else {
         bn_mod(zr.z, zr.z, zr.order);
@@ -174,7 +174,7 @@ ZR hashToZR(const bytes_vec& b)
     memset(digest, 0, digest_len);
     SHA_FUNC(digest, data.data(), static_cast<int>(data.size()));
     bn_read_bin(zr.z, digest, digest_len);
-    if (bn_cmp(zr.z, zr.order) == CMP_GT) {
+    if (bn_cmp(zr.z, zr.order) == RLC_GT) {
         bn_mod(zr.z, zr.z, zr.order);
     }
     return zr;
@@ -187,7 +187,7 @@ size_t ZR::byte_size() const
 
 bool ZR::ismember() const
 {
-    return ((bn_cmp(z, order) < CMP_EQ) && (bn_sign(z) == BN_POS));
+    return ((bn_cmp(z, order) < RLC_EQ) && (bn_sign(z) == RLC_POS));
 }
 
 std::vector<uint8_t> ZR::getBytes() const
@@ -214,7 +214,7 @@ ZR operator<<(const ZR& a, int b)
     // left shift
     ZR zr;
     bn_lsh(zr.z, a.z, b);
-    if (bn_cmp(zr.z, zr.order) == CMP_GT) {
+    if (bn_cmp(zr.z, zr.order) == RLC_GT) {
         bn_mod(zr.z, zr.z, zr.order);
     }
     return zr;
@@ -604,7 +604,7 @@ void GT::getBytes(bool compress, const size_t out_len, uint8_t* out) const
             out[i] = 0x00;
         }
     }
-    gt_write_bin(out, static_cast<int>(MIN(l, out_len)), gg.g, compress);
+    gt_write_bin(out, static_cast<int>(RLC_MIN(l, out_len)), gg.g, compress);
 }
 
 
@@ -646,13 +646,13 @@ relicResourceHandle::relicResourceHandle(const bool allowAlreadyInitialized)
         throw std::runtime_error("ERROR Relic already initialized.");
     }
     const int err_code = core_init();
-    if (err_code != STS_OK) {
+    if (err_code != RLC_OK) {
         throw std::runtime_error(
             "ERROR cannot initialize  relic: core_init returned: "
             + std::to_string(err_code) + ".");
     }
     const int err_code_2 = pc_param_set_any();
-    if (err_code_2 != STS_OK) {
+    if (err_code_2 != RLC_OK) {
         throw std::runtime_error(
             "ERROR cannot initialize  relic: pc_param_set_any returned: "
             + std::to_string(err_code_2) + ".");
@@ -687,7 +687,7 @@ PairingGroup::~PairingGroup()
 ZR PairingGroup::randomZR() const
 {
     ZR zr, tt;
-    bn_rand(tt.z, BN_POS, bn_bits(grp_order));
+    bn_rand(tt.z, RLC_POS, bn_bits(grp_order));
     bn_mod(zr.z, tt.z, grp_order);
     return zr;
 }
@@ -698,7 +698,7 @@ ZR PairingGroup::pseudoRandomZR(const sse::crypto::Prf<kPrfOutputSize>& prf,
     ZR                                  zr, tt;
     std::array<uint8_t, kPrfOutputSize> prf_out = prf.prf(seed);
     bn_read_bin(tt.z, prf_out.data(), kPrfOutputSize);
-    //        bn_rand(tt.z, BN_POS, bn_bits(grp_order));
+    //        bn_rand(tt.z, RLC_POS, bn_bits(grp_order));
     bn_mod(zr.z, tt.z, grp_order);
     return zr;
 }

--- a/src/ppke/relic_wrapper/relic_api.h
+++ b/src/ppke/relic_wrapper/relic_api.h
@@ -77,7 +77,7 @@ static_assert(MULTI == OPENMP,
 // Do it ourself if necessary.
 
 #ifndef RELIC_BN_BYTES
-#define RELIC_BN_BYTES CEIL(RELIC_BN_BITS, 8)
+#define RELIC_BN_BYTES RLC_CEIL(RLC_BN_BITS, 8)
 #endif
 
 namespace relicxx {
@@ -215,7 +215,7 @@ public:
     friend std::ostream& operator<<(std::ostream& /*s*/, const ZR& /*zr*/);
     friend bool          operator==(const ZR& x, const ZR& y)
     {
-        if (bn_cmp(x.z, y.z) == CMP_EQ) {
+        if (bn_cmp(x.z, y.z) == RLC_EQ) {
             {
                 {
                     {
@@ -240,7 +240,7 @@ public:
     }
     friend bool operator!=(const ZR& x, const ZR& y)
     {
-        if (bn_cmp(x.z, y.z) != CMP_EQ) {
+        if (bn_cmp(x.z, y.z) != RLC_EQ) {
             {
                 {
                     {
@@ -265,7 +265,7 @@ public:
     }
     friend bool operator>(const ZR& x, const ZR& y)
     {
-        if (bn_cmp(x.z, y.z) == CMP_GT) {
+        if (bn_cmp(x.z, y.z) == RLC_GT) {
             {
                 {
                     {
@@ -290,7 +290,7 @@ public:
     }
     friend bool operator<(const ZR& x, const ZR& y)
     {
-        if (bn_cmp(x.z, y.z) == CMP_LT) {
+        if (bn_cmp(x.z, y.z) == RLC_LT) {
             {
                 {
                     {
@@ -321,8 +321,8 @@ ZR hashToZR(const bytes_vec& b);
 class G1
 {
 public:
-    constexpr static uint16_t kByteSize        = 1 + 2 * FP_BYTES;
-    constexpr static uint16_t kCompactByteSize = 1 + FP_BYTES;
+    constexpr static uint16_t kByteSize        = 1 + 2 * RLC_FP_BYTES;
+    constexpr static uint16_t kCompactByteSize = 1 + RLC_FP_BYTES;
 
 
     g1_t g;
@@ -412,19 +412,19 @@ public:
     friend std::ostream& operator<<(std::ostream& /*s*/, const G1& /*g1*/);
     friend bool          operator==(const G1& x, const G1& y)
     {
-        return g1_cmp(x.g, y.g) == CMP_EQ;
+        return g1_cmp(x.g, y.g) == RLC_EQ;
     }
     friend bool operator!=(const G1& x, const G1& y)
     {
-        return g1_cmp(x.g, y.g) != CMP_EQ;
+        return g1_cmp(x.g, y.g) != RLC_EQ;
     }
 };
 
 class G2
 {
 public:
-    constexpr static uint16_t kByteSize        = 1 + 4 * FP_BYTES;
-    constexpr static uint16_t kCompactByteSize = 1 + 2 * FP_BYTES;
+    constexpr static uint16_t kByteSize        = 1 + 4 * RLC_FP_BYTES;
+    constexpr static uint16_t kCompactByteSize = 1 + 2 * RLC_FP_BYTES;
 
     g2_t g;
     bool isInit{false};
@@ -511,19 +511,19 @@ public:
     friend std::ostream& operator<<(std::ostream& s, const G2& /*g2*/);
     friend bool          operator==(const G2& x, const G2& y)
     {
-        return g2_cmp(const_cast<G2&>(x).g, const_cast<G2&>(y).g) == CMP_EQ;
+        return g2_cmp(const_cast<G2&>(x).g, const_cast<G2&>(y).g) == RLC_EQ;
     }
     friend bool operator!=(const G2& x, const G2& y)
     {
-        return g2_cmp(const_cast<G2&>(x).g, const_cast<G2&>(y).g) != CMP_EQ;
+        return g2_cmp(const_cast<G2&>(x).g, const_cast<G2&>(y).g) != RLC_EQ;
     }
 };
 
 class GT
 {
 public:
-    constexpr static uint16_t kByteSize        = 12 * FP_BYTES;
-    constexpr static uint16_t kCompactByteSize = 8 * FP_BYTES;
+    constexpr static uint16_t kByteSize        = 12 * RLC_FP_BYTES;
+    constexpr static uint16_t kCompactByteSize = 8 * RLC_FP_BYTES;
 
     gt_t g;
     bool isInit{false};
@@ -610,11 +610,11 @@ public:
     friend std::ostream& operator<<(std::ostream& s, const GT& /*gt*/);
     friend bool          operator==(const GT& x, const GT& y)
     {
-        return gt_cmp(const_cast<GT&>(x).g, const_cast<GT&>(y).g) == CMP_EQ;
+        return gt_cmp(const_cast<GT&>(x).g, const_cast<GT&>(y).g) == RLC_EQ;
     }
     friend bool operator!=(const GT& x, const GT& y)
     {
-        return gt_cmp(const_cast<GT&>(x).g, const_cast<GT&>(y).g) != CMP_EQ;
+        return gt_cmp(const_cast<GT&>(x).g, const_cast<GT&>(y).g) != RLC_EQ;
     }
 };
 


### PR DESCRIPTION
Recent changes in Relic made the compilation break: many constant names were changed to include the `RLC` prefix. The CMake of the library was also changed.

This update should fix OpenSSE/opensse-schemes#12.