### PR TITLE
Minor 0.3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.1)
 
-project(libsse_crypto VERSION 0.3 DESCRIPTION "OpenSSE's cryptographic library")
+project(
+    libsse_crypto
+    VERSION 0.3
+    DESCRIPTION "OpenSSE's cryptographic library"
+)
 
 # Needed on Mac OS for the fuzzing targets
 if(APPLE)
@@ -12,17 +16,14 @@ endif()
 # myself): https://gitlab.kitware.com/cmake/cmake/issues/18785
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
-list(
-    APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/externals/CMake-codecov/cmake"
+list(APPEND CMAKE_MODULE_PATH
+     "${CMAKE_SOURCE_DIR}/externals/CMake-codecov/cmake"
 )
-list(
-    APPEND
-        CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/externals/sanitizers-cmake/cmake"
+list(APPEND CMAKE_MODULE_PATH
+     "${CMAKE_SOURCE_DIR}/externals/sanitizers-cmake/cmake"
 )
-list(
-    APPEND
-        CMAKE_MODULE_PATH
-        "${CMAKE_SOURCE_DIR}/externals/cmake-flag-manager/cmake"
+list(APPEND CMAKE_MODULE_PATH
+     "${CMAKE_SOURCE_DIR}/externals/cmake-flag-manager/cmake"
 )
 # Build in Debug mode by default
 set(default_build_type "Debug")
@@ -34,8 +35,8 @@ option(opensse_ENABLE_WSHADOW "Enable shadow warning" OFF)
 option(opensse_ENABLE_PEDANTIC "Enable pedantic warning" ON)
 option(opensse_ENABLE_WERROR "Make all warnings into errors" ON)
 option(opensse_ENABLE_BASIC_WARNINGS "Enable basic additional warnings" ON)
-option(
-    opensse_ENABLE_ADVANCED_WARNINGS "Enable advanced additional warnings" ON
+option(opensse_ENABLE_ADVANCED_WARNINGS "Enable advanced additional warnings"
+       ON
 )
 option(
     opensse_OPTIMIZE_FOR_NATIVE_ARCH
@@ -76,7 +77,10 @@ if(opensse_ENABLE_PEDANTIC)
 endif()
 
 if(opensse_ENABLE_WERROR)
-    save_compile_option(-Wno-error=unknown-pragmas -Werror)
+    save_compile_option(
+        -Wno-error=unknown-pragmas -Wno-error=unused-function
+        -Wno-error=useless-cast -Werror
+    )
 endif()
 
 if(opensse_OPTIMIZE_FOR_NATIVE_ARCH)
@@ -105,11 +109,12 @@ endif()
 
 if(opensse_ENABLE_ADVANCED_WARNINGS)
     save_compile_option(
-        LIST_NAME "Lib_Warnings"
+        LIST_NAME
+        "Lib_Warnings"
         # -Weffc++ # Weffc++ is too annoying on gcc
         -Wextra-semi # Extra, unnecessary semicolumns
-        # -Wsign-conversion # To be enabled
-        # -Wconversion # Extremely strict on gcc
+        # -Wsign-conversion # To be enabled -Wconversion # Extremely strict on
+        # gcc
         -Wno-c++98-compat # No need to be C++98 compatible: we require C++11
         -Wno-c++98-compat-pedantic
         -Wno-error=padded
@@ -140,20 +145,20 @@ endif()
 find_package(OpenSSL 1.0.0) # Optional
 
 if(OPENSSL_FOUND)
-    add_definitions(-DWITH_OPENSSL)
+    # add_definitions(-DWITH_OPENSSL)
 endif()
 
-list(
-    APPEND
-        LCOV_REMOVE_PATTERNS
-        '${CMAKE_CURRENT_SOURCE_DIR}/tests/*'
-        '${CMAKE_CURRENT_SOURCE_DIR}/bench/*'
-        '${CMAKE_CURRENT_SOURCE_DIR}/externals/*'
+list(APPEND LCOV_REMOVE_PATTERNS '${CMAKE_CURRENT_SOURCE_DIR}/tests/*'
+     '${CMAKE_CURRENT_SOURCE_DIR}/bench/*'
+     '${CMAKE_CURRENT_SOURCE_DIR}/externals/*'
 )
 
 # To avoid building GTest twice
 if(NOT TARGET gtest)
-    set(BUILD_GMOCK OFF CACHE BOOL "Disable GMock" FORCE)
+    set(BUILD_GMOCK
+        OFF
+        CACHE BOOL "Disable GMock" FORCE
+    )
     add_subdirectory(externals/googletest)
     # Not adding the sanitizers might cause ASan false positives. See https://gi
     # thub.com/google/sanitizers/wiki/AddressSanitizerContainerOverflow
@@ -188,8 +193,7 @@ if(OPENSSL_FOUND)
     set_property(TARGET debug_tool PROPERTY CXX_STANDARD 11)
 
     target_include_directories(
-        debug_tool
-        PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
+        debug_tool PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
 
     target_link_libraries(debug_tool sse_crypto ${OPENSSL_CRYPTO_LIBRARY})

--- a/install_dependencies/install_libsodium.sh
+++ b/install_dependencies/install_libsodium.sh
@@ -2,10 +2,10 @@
 set -ex
 
 
-wget -q https://download.libsodium.org/libsodium/releases/libsodium-1.0.16.tar.gz
-tar xf libsodium-1.0.16.tar.gz
+wget -q https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz
+tar xf libsodium-1.0.18.tar.gz
 
-cd libsodium-1.0.16
+cd libsodium-1.0.18
 
 ./configure
 make -j4

--- a/install_dependencies/install_relic_easy.sh
+++ b/install_dependencies/install_relic_easy.sh
@@ -4,7 +4,7 @@
 
 set -ex
 
-git clone https://github.com/relic-toolkit/relic.git
+git clone -b relic-toolkit-0.5.0 https://github.com/relic-toolkit/relic.git
 cd relic
 mkdir build
 cd build

--- a/install_dependencies/install_relic_gmp.sh
+++ b/install_dependencies/install_relic_gmp.sh
@@ -4,7 +4,7 @@
 
 set -ex
 
-git clone https://github.com/relic-toolkit/relic.git
+git clone -b relic-toolkit-0.5.0 https://github.com/relic-toolkit/relic.git
 cd relic
 mkdir build
 cd build

--- a/install_dependencies/install_relic_x64_asm.sh
+++ b/install_dependencies/install_relic_x64_asm.sh
@@ -4,7 +4,7 @@
 
 set -ex
 
-git clone https://github.com/relic-toolkit/relic.git
+git clone -b relic-toolkit-0.5.0 https://github.com/relic-toolkit/relic.git
 cd relic
 mkdir build
 cd build

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(relic REQUIRED)
 if(OPENSSL_FOUND)
     message(STATUS "OpenSSL Include directories:" ${OPENSSL_INCLUDE_DIR})
 
-    add_definitions(-DWITH_OPENSSL)
+    # add_definitions(-DWITH_OPENSSL)
 else()
     if(RSA_IMPL_OPENSSL)
         message(

--- a/src/mbedtls/pk.h
+++ b/src/mbedtls/pk.h
@@ -114,12 +114,17 @@ typedef struct
  */
 static inline mbedtls_rsa_context *mbedtls_pk_rsa( const mbedtls_pk_context pk )
 {
+#ifdef __cplusplus
 #pragma GCC diagnostic push
 // As the function is static inline, it seems we have to new new C++ casts when
 // including the head in a C++ translation unit
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+#endif
+
     return ((mbedtls_rsa_context*)(pk).pk_ctx);
+#ifdef __cplusplus
 #pragma GCC diagnostic pop
+#endif
 }
 #endif /* MBEDTLS_RSA_C */
 

--- a/src/ppke/relic_wrapper/relic_api.cpp
+++ b/src/ppke/relic_wrapper/relic_api.cpp
@@ -8,7 +8,8 @@
 
 namespace relicxx {
 
-[[noreturn]] void ro_error() {
+[[noreturn]] void ro_error()
+{
     throw std::invalid_argument("writing to read only object");
 }
 
@@ -315,7 +316,7 @@ G1 operator-(const G1& x)
 G1 power(const G1& g, const ZR& zr)
 {
     G1 g1;
-    g1_mul(g1.g, g.g, zr.z);
+    g1_mul(g1.g, const_cast<ep_st*>(g.g), const_cast<bn_st*>(zr.z));
     return g1;
 }
 
@@ -341,7 +342,7 @@ bool G1::ismember(const bn_t order) const
     g1_t r;
     g1_inits(r);
 
-    g1_mul(r, g, order);
+    g1_mul(r, const_cast<ep_st*>(g), const_cast<bn_st*>(order));
     if (g1_is_infty(r) == 1) {
         result = true;
     }


### PR DESCRIPTION
Fix minor issues introduced by new versions of Relic and the deprecation of OpenSSL 1.0 :
* Use the new Relic API (version 0.5.0)
* Disable OpenSSL by default